### PR TITLE
support "source assets" to improve DX of injecting scripts into the WebView

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "files.associations": {
+    "*.wvcss": "css",
+    "*.wvhtml": "html",
+    "*.wvjs": "javascript",
+    "*.wvts": "typescript"
+  }
 }

--- a/babel-transformer.js
+++ b/babel-transformer.js
@@ -1,0 +1,42 @@
+// Metro has an awkward property, `transformer.babelTransformerPath` that takes
+// a path to a single Babel transformer. Expo uses a custom one, which we want
+// to extend. Fortunately, they expose it explicitly for this kind of use case:
+// @see https://github.com/expo/expo/blob/0b5b03c0b77769e671c214140032661ade8fef3e/docs/pages/versions/v52.0.0/config/metro.mdx#extending-the-babel-transformer
+
+const upstreamTransformer = require('@expo/metro-config/babel-transformer');
+const { transformSync } = require('@babel/core');
+
+/**
+ * A Babel transformer to consume certain filetypes as "source assets" (i.e. as
+ * strings rather than parsed code).
+ *
+ * Needs to be used alongside a Metro pseudo-plugin, TypeScript declarations,
+ * and with VS Code `files.associations` settings configured.
+ *
+ * @param {object} obj
+ * @param {string} obj.src
+ * @param {string} obj.filename
+ * @param {import("@babel/core").TransformOptions} [obj.options]
+ * @param {unknown} obj.plugins
+ */
+module.exports.transform = async ({ src, filename, options, plugins }) => {
+  if (sourceAssetExtensions.some(extension => filename.endsWith(extension))) {
+    // For TypeScript files, transpile to JS first.
+    if (filename.endsWith('.wvts')) {
+      const transpiled = transformSync(src, {
+        // We set `allExtensions: true`, otherwise `.wvts` isn't recognised as
+        // TypeScript at all because the plugin only looks for `.ts` by default.
+        presets: [['@babel/preset-typescript', { allExtensions: true }]],
+        filename,
+      });
+      src = transpiled.code ?? '';
+    }
+
+    src = `const source = ${JSON.stringify(src)};\nexport default source;`;
+  }
+
+  // Pass the source (modified or not) through the upstream Expo transformer.
+  return upstreamTransformer.transform({ src, filename, options, plugins });
+};
+
+const sourceAssetExtensions = ['.wvts', '.wvjs', '.wvhtml', '.wvcss'];

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,49 @@
-// metro.config.js
+const path = require('node:path');
 const { getDefaultConfig } = require('@expo/metro-config');
 const { makeMetroConfig } = require('@rnx-kit/metro-config');
 
-const config = getDefaultConfig(__dirname);
-module.exports = makeMetroConfig(config);
+let config = getDefaultConfig(__dirname);
+config = makeMetroConfig(config);
+withSourceAssets(config, {
+  babelTransformerPath: path.resolve(__dirname, 'babel-transformer.js'),
+  sourceAssetExts: ['wvjs', 'wvts', 'wvcss', 'wvhtml'],
+});
+
+/**
+ * A Metro pseudo-plugin to consume certain filetypes as "source assets" (i.e.
+ * as strings rather than parsed code). Mutates the input Metro config.
+ *
+ * Needs to be used alongside a Babel transformer, TypeScript declarations, and
+ * with VS Code `files.associations` settings configured.
+ *
+ * @param {import("metro-config").MetroConfig} config
+ * @param {object} args
+ * @param {string} args.babelTransformerPath The path to your Babel transformer,
+ * which should extend your existing one (try logging out the existing value and
+ * inspecting it). See [Extending the Babel transformer](https://github.com/expo/expo/blob/0b5b03c0b77769e671c214140032661ade8fef3e/docs/pages/versions/v52.0.0/config/metro.mdx#extending-the-babel-transformer) for
+ * guidance. The docs are for Expo SDK 52, but the same concepts apply even in
+ * bare React Native apps.
+ * @param {Array<string>} args.sourceAssetExts The file extensions you want to
+ * be treated as source assets. These should match whatever your Babel
+ * transformer and TypeScript declarations handle. Example:
+ * `['wvjs', 'wvts', 'wvcss', 'wvhtml']`
+ */
+function withSourceAssets(config, { babelTransformerPath, sourceAssetExts }) {
+  if (!config.transformer) {
+    config.transformer = {};
+  }
+  config.transformer.babelTransformerPath = babelTransformerPath;
+
+  if (!config.resolver) {
+    config.resolver = {};
+  }
+  if (!config.resolver.sourceExts) {
+    config.resolver.sourceExts = [];
+  }
+
+  config.resolver.sourceExts = [
+    ...new Set([...config.resolver.sourceExts, ...sourceAssetExts]),
+  ];
+}
+
+module.exports = config;

--- a/source-asset-support.d.ts
+++ b/source-asset-support.d.ts
@@ -1,0 +1,24 @@
+/**
+ * TypeScript declarations to consume certain filetypes as "source assets" (i.e.
+ * as strings rather than parsed code).
+ *
+ * Needs to be used alongside a Metro pseudo-plugin, Babel transformer, and with
+ * VS Code `files.associations` settings configured.
+ */
+
+declare module '*.wvcss' {
+  const source: string;
+  export default source;
+}
+declare module '*.wvhtml' {
+  const source: string;
+  export default source;
+}
+declare module '*.wvjs' {
+  const source: string;
+  export default source;
+}
+declare module '*.wvts' {
+  const source: string;
+  export default source;
+}

--- a/src/library-screen.tsx
+++ b/src/library-screen.tsx
@@ -18,6 +18,11 @@ import type { Book } from '@/types/book.types';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from './navigation.types';
 
+import ExampleJS from './source-assets/example.wvjs';
+import ExampleTS from './source-assets/example.wvts';
+import ExampleCSS from './source-assets/example.wvcss';
+import ExampleHTML from './source-assets/example.wvhtml';
+
 export default function LibraryScreen({
   navigation,
 }: NativeStackScreenProps<RootStackParamList, 'Library'>) {
@@ -33,6 +38,13 @@ export default function LibraryScreen({
           ),
     [libraryStatus],
   );
+
+  React.useEffect(() => {
+    console.log(`Imported ExampleJS:\n${ExampleJS}`);
+    console.log(`Imported ExampleTS:\n${ExampleTS}`);
+    console.log(`Imported ExampleCSS:\n${ExampleCSS}`);
+    console.log(`Imported ExampleHTML:\n${ExampleHTML}`);
+  }, []);
 
   // Prompt the user to pick the directory where the novels are stored.
   const onPressPicker = React.useCallback(async () => {

--- a/src/source-assets/example.wvcss
+++ b/src/source-assets/example.wvcss
@@ -1,0 +1,4 @@
+::highlight(ruby-highlight) {
+  color: black;
+  background-color: yellow;
+}

--- a/src/source-assets/example.wvhtml
+++ b/src/source-assets/example.wvhtml
@@ -1,0 +1,5 @@
+<!--?xml version='1.0' encoding='utf-8'?-->
+<html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja">
+  <head></head>
+  <body></body>
+</html>

--- a/src/source-assets/example.wvjs
+++ b/src/source-assets/example.wvjs
@@ -1,0 +1,8 @@
+export const abc = 123;
+const foo = 'bar';
+function def() {
+  return 'ghi';
+}
+class JKL {}
+export class MNO {}
+export const PQR = () => {};

--- a/src/source-assets/example.wvts
+++ b/src/source-assets/example.wvts
@@ -1,0 +1,28 @@
+function* traverseBaseText(node: Node) {
+  const treeWalker = document.createTreeWalker(
+    node,
+    // We need SHOW_ELEMENT to filter out all <rt> subtrees, while the payload
+    // we're actually interested in is SHOW_TEXT.
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+    node => {
+      switch (node.nodeName) {
+        case 'RT':
+          return NodeFilter.FILTER_REJECT;
+        case '#text':
+          return NodeFilter.FILTER_ACCEPT;
+        default:
+          return NodeFilter.FILTER_SKIP;
+      }
+    },
+  );
+
+  // Make the traversal inclusive of the target node.
+  if (node.nodeName === '#text') {
+    yield node;
+  }
+
+  let nextNode: Node | null;
+  while ((nextNode = treeWalker.nextNode())) {
+    yield nextNode;
+  }
+}


### PR DESCRIPTION
This PR implements support for what I'm calling "source assets" (source files to be consumed as a string rather than parsed as code). Not quite a source, not quite an asset.

The support relies on four parts:

1. A custom **Babel transformer** to look for files ending with `.wvts`, `.wvjs`, `.wvcss`, or `.wvhtml` and to handle them specially.
    - Such files are transformed into a CommonJS module (Hermes doesn't implement ESM) that default-exports the original contents as a string.
    - For `.wvts`, the TypeScript is stripped down to JavaScript and it's *that* that we export as a string.
    - Any other files are handled using the original Babel transformer (in our case as an Expo app, the [default one](https://github.com/expo/expo/blob/14cce62a517f564c20cc10f098ac3b6550756200/packages/%40expo/metro-config/build/babel-transformer.js#L81) from Expo).
2. A **Metro pseudo-plugin** to reference that Babel transformer (so that Metro actually applies the transforms) and recognise the new file extensions (so that Metro actually reads the files).
3. Some **TypeScript declarations** to recognise those new file extensions (to keep the TypeScript language server happy).
4. Some **VS Code workspace settings** to recognise those new file extensions and thus run the appropriate language server (for Intellisense).

I've created some example files in `src/source-assets` and demonstrated how to import them in `src/library-screen.tsx`.

I'm pleased to see that changes to the source files *do* prompt HMR updates. Very nice.