### PR TITLE
Handle being unable to satisfy preferred inline size for a given orientation

### DIFF
--- a/src/source-assets/injected-css.wvcss
+++ b/src/source-assets/injected-css.wvcss
@@ -10,6 +10,8 @@
   --paranovel-popover-show-more-button-block-size: 32px;
   --paranovel-popover-inset-size: 8px;
   --paranovel-max-readable-inline-size: 600px;
+  --paranovel-popover-minimum-inline-size: 200px;
+  --paranovel-popover-minimum-block-size: 100px;
   --paranovel-popover-background-color: #222;
 
   --paranovel-popover-definition-font-size: 14px;

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -640,20 +640,25 @@ function calculatePopoverLayout({
       }
     })
     .sort((a, b) => {
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+      const A_BEFORE_B = -1;
+      const NO_CHANGE = 0;
+      const B_BEFORE_A = 1;
+
       // If one of the two has an arrow out of bounds, sort the one whose arrow
       // is in bounds to the front.
       //
       // If they both have an arrow out of bounds, continue to the next check.
       if (a.arrow.x < popoverInsetSize || a.arrow.y < popoverInsetSize) {
         if (b.arrow.x >= popoverInsetSize || b.arrow.y >= popoverInsetSize) {
-          return 1;
+          return B_BEFORE_A;
         } else {
           // They're both out of bounds. We could sort by the one that's least
           // out of bounds, or just invest our time improving the layout
           // algorithm instead.
         }
       } else if (b.arrow.x < popoverInsetSize || b.arrow.y < popoverInsetSize) {
-        return -1;
+        return A_BEFORE_B;
       }
 
       const aFits =
@@ -663,7 +668,13 @@ function calculatePopoverLayout({
         b.popover.width <= b.popover.maxWidth &&
         b.popover.height <= b.popover.maxHeight;
 
-      return aFits ? (bFits ? 0 : -1) : bFits ? 1 : 0;
+      return aFits
+        ? bFits
+          ? NO_CHANGE
+          : A_BEFORE_B
+        : bFits
+        ? B_BEFORE_A
+        : NO_CHANGE;
     });
 
   return {

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -175,10 +175,12 @@ function updatePopover({
     popover.style.display = 'block';
     popover.style.visibility = 'hidden';
 
+    // 'auto' may produce a floating-point number, while clientWidth and
+    // clientHeight produce a floored version of that number
     popover.style.inlineSize = 'auto';
     popover.style.minInlineSize = `${popoverMinimumInlineSize}px`;
     popover.style.maxInlineSize =
-      'min(calc(100vi - var(--paranovel-popover-inset-size) * 2), var(--paranovel-max-readable-inline-size))';
+      'round(down, min(calc(100vi - var(--paranovel-popover-inset-size) * 2), var(--paranovel-max-readable-inline-size)), 1px)';
     popover.style.blockSize = 'auto';
     // popover.style.maxBlockSize = '50%';
 

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -156,59 +156,83 @@ function updatePopover({
   // and let the block size expand as much as it likes in order to display all
   // its results.
 
-  popover.style.left = 'var(--paranovel-popover-inset-size)';
-  popover.style.top = 'var(--paranovel-popover-inset-size)';
-  popover.style.boxSizing = 'border-box';
-  popover.style.display = 'block';
-  popover.style.visibility = 'hidden';
+  /**
+   * @param {object} params
+   * @param {boolean} params.hasMultipleResults
+   * @param {number} params.popoverMinimumInlineSize
+   * @param {number} params.blockSizeForShowMoreButton
+   * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr"} params.popoverWritingMode
+   */
+  const getPreferredSize = ({
+    hasMultipleResults,
+    popoverMinimumInlineSize,
+    blockSizeForShowMoreButton,
+    popoverWritingMode,
+  }) => {
+    popover.style.left = 'var(--paranovel-popover-inset-size)';
+    popover.style.top = 'var(--paranovel-popover-inset-size)';
+    popover.style.boxSizing = 'border-box';
+    popover.style.display = 'block';
+    popover.style.visibility = 'hidden';
 
-  popover.style.inlineSize = 'auto';
-  popover.style.minInlineSize = `${popoverMinimumInlineSize}px`;
-  popover.style.maxInlineSize =
-    'min(calc(100vi - var(--paranovel-popover-inset-size) * 2), var(--paranovel-max-readable-inline-size))';
-  popover.style.blockSize = 'auto';
-  // popover.style.maxBlockSize = '50%';
+    popover.style.inlineSize = 'auto';
+    popover.style.minInlineSize = `${popoverMinimumInlineSize}px`;
+    popover.style.maxInlineSize =
+      'min(calc(100vi - var(--paranovel-popover-inset-size) * 2), var(--paranovel-max-readable-inline-size))';
+    popover.style.blockSize = 'auto';
+    // popover.style.maxBlockSize = '50%';
 
-  // FIXME: clientHeight/clientWidth floor the true values, so if you take their
-  // values as written, you may end up underestimating the size needed to fit
-  // content. For the time being, we add an extra pixel to each size to prefer
-  // overestimating.
-  //
-  // There may be other sub-pixel values to track down elsewhere in our
-  // measurements (e.g. scroll position and viewport size).
-  const popoverSizeToFitAllResults = {
-    width: popover.clientWidth + 1,
-    height: popover.clientHeight + 1,
-  };
-
-  const popoverWritingMode = 'horizontal-tb';
-
-  // When there are multiple results to show, we size the popover to fit just
-  // the first result, providing a "show more" button to reveal the rest.
-  let popoverSizeToFitFirstResult = popoverSizeToFitAllResults;
-  // Avoid flushing layout again if there's only a single result container.
-  if (results.length > 1) {
-    popover.classList.add('size-to-first-result-container');
-    popoverSizeToFitFirstResult = {
+    // FIXME: clientHeight/clientWidth floor the true values, so if you take
+    // their values as written, you may end up underestimating the size needed
+    // to fit content. For the time being, we add an extra pixel to each size to
+    // prefer overestimating.
+    //
+    // There may be other sub-pixel values to track down elsewhere in our
+    // measurements (e.g. scroll position and viewport size).
+    const popoverSizeToFitAllResults = {
       width: popover.clientWidth + 1,
       height: popover.clientHeight + 1,
     };
-    const blockSizeForShowMoreButton = parseFloat(
-      (
-        getComputedStyle(popover).getPropertyValue(
-          '--paranovel-popover-show-more-button-block-size',
-        ) || '0px'
-      ).split('px')[0],
-    );
-    if (popoverWritingMode === 'horizontal-tb') {
-      popoverSizeToFitFirstResult.height += blockSizeForShowMoreButton;
-    } else {
-      popoverSizeToFitFirstResult.width += blockSizeForShowMoreButton;
+
+    // When there are multiple results to show, we size the popover to fit just
+    // the first result, providing a "show more" button to reveal the rest.
+    let popoverSizeToFitFirstResult = popoverSizeToFitAllResults;
+    // Avoid flushing layout again if there's only a single result container.
+    if (hasMultipleResults) {
+      popover.classList.add('size-to-first-result-container');
+      popoverSizeToFitFirstResult = {
+        width: popover.clientWidth + 1,
+        height: popover.clientHeight + 1,
+      };
+      if (popoverWritingMode === 'horizontal-tb') {
+        popoverSizeToFitFirstResult.height += blockSizeForShowMoreButton;
+      } else {
+        popoverSizeToFitFirstResult.width += blockSizeForShowMoreButton;
+      }
+
+      popover.classList.remove('size-to-first-result-container');
+      popover.classList.add('with-show-more-button');
     }
 
-    popover.classList.remove('size-to-first-result-container');
-    popover.classList.add('with-show-more-button');
-  }
+    return { popoverSizeToFitAllResults, popoverSizeToFitFirstResult };
+  };
+
+  const blockSizeForShowMoreButton = parseFloat(
+    (
+      getComputedStyle(popover).getPropertyValue(
+        '--paranovel-popover-show-more-button-block-size',
+      ) || '0px'
+    ).split('px')[0],
+  );
+  const popoverWritingMode = 'horizontal-tb';
+
+  const { popoverSizeToFitAllResults, popoverSizeToFitFirstResult } =
+    getPreferredSize({
+      hasMultipleResults: results.length > 1,
+      popoverMinimumInlineSize,
+      blockSizeForShowMoreButton,
+      popoverWritingMode,
+    });
 
   console.log(
     `popoverSizeToFitAllResults ${JSON.stringify(popoverSizeToFitAllResults)}`,
@@ -571,6 +595,7 @@ function calculatePopoverLayout(params) {
 function calculatePopoverLayoutForPlacement({
   boundingClientRect,
   clientRect = boundingClientRect,
+  popoverWritingMode,
   popoverPreferredSize,
   arrowSize,
   popoverInsetSize,
@@ -622,6 +647,20 @@ function calculatePopoverLayoutForPlacement({
             boundingClientRect.top - popoverInsetSize - arrowSize.length,
         },
       };
+
+      // FIXME: There are cases where the popover is able to satisfy its
+      // preferred block size just fine, but not its preferred inline size. This
+      // can make the block size meaningless, because it referred to a larger
+      // inline size and so may now be too small and need to scroll. See
+      // 打ち付ける.
+      if (
+        popoverWritingMode === 'horizontal-tb'
+          ? above.popover.width > above.popover.maxWidth
+          : above.popover.height > above.popover.maxHeight
+      ) {
+        // Lay out again
+      }
+
       const aboveAdjusted = {
         popoverPlacement: 'above',
         arrow: above.arrow,

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -143,6 +143,14 @@ function updatePopover({
     scrollTop: getViewportScrollTop(),
   };
 
+  const popoverMinimumInlineSize = parseFloat(
+    (
+      getComputedStyle(popover).getPropertyValue(
+        '--paranovel-popover-minimum-inline-size',
+      ) || '0px'
+    ).split('px')[0],
+  );
+
   // == First layout pass ==
   // In this pass, we restrict the popover's inline size to something readable,
   // and let the block size expand as much as it likes in order to display all
@@ -155,6 +163,7 @@ function updatePopover({
   popover.style.visibility = 'hidden';
 
   popover.style.inlineSize = 'auto';
+  popover.style.minInlineSize = `${popoverMinimumInlineSize}px`;
   popover.style.maxInlineSize =
     'min(calc(100vi - var(--paranovel-popover-inset-size) * 2), var(--paranovel-max-readable-inline-size))';
   popover.style.blockSize = 'auto';
@@ -222,13 +231,6 @@ function updatePopover({
     (
       getComputedStyle(popover).getPropertyValue(
         '--paranovel-popover-inset-size',
-      ) || '0px'
-    ).split('px')[0],
-  );
-  const popoverMinimumInlineSize = parseFloat(
-    (
-      getComputedStyle(popover).getPropertyValue(
-        '--paranovel-popover-minimum-inline-size',
       ) || '0px'
     ).split('px')[0],
   );

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -192,20 +192,20 @@ function updatePopover({
     const popoverMaxInlineSize = parseFloat(
       getComputedStyle(popover).maxInlineSize.split('px')[0],
     );
-    console.log('!! popoverMaxInlineSize', {
+    console.log('popoverMaxInlineSize', {
       popoverMaxInlineSize,
       clientWidth: popover.clientWidth,
     });
 
-    // FIXME: clientHeight/clientWidth floor the true values, so if you take
-    // their values as written, you may end up underestimating the size needed
-    // to fit content. We add an extra pixel to each size to prefer
-    // overestimating, and clamp it to the computed maxInlineSize to avoid the
-    // added pixel breaking the original constraints. This is less of a concern
-    // for the block size, where an overestimate does not affect text flow.
+    // clientHeight/clientWidth floor the true values, so if you take their
+    // values as written, you may end up underestimating the size needed to fit
+    // content. We add an extra pixel to each size to prefer overestimating, and
+    // clamp it to the computed maxInlineSize to avoid the added pixel breaking
+    // the original constraints. This is less of a concern for the block size,
+    // where an overestimate does not affect text flow.
     //
     // There may be other sub-pixel values to track down elsewhere in our
-    // measurements (e.g. scroll position and viewport size).
+    // measurements (e.g. scroll position and bounding box).
     const popoverSizeToFitAllResults = {
       width:
         popoverWritingMode === 'horizontal-tb'
@@ -460,15 +460,6 @@ function calculatePopoverLayout(params) {
     popoverPreferredSize,
   });
 
-  // const preferredInlineSize =
-  //   popoverWritingMode === 'horizontal-tb'
-  //     ? popoverPreferredSize.width
-  //     : popoverPreferredSize.height;
-  // const preferredBlockSize =
-  //   popoverWritingMode === 'horizontal-tb'
-  //     ? popoverPreferredSize.height
-  //     : popoverPreferredSize.width;
-
   /**
    * The order of preference as to where the popover should be placed relative
    * to the content to avoid downstream (not yet read) text, if multiple
@@ -644,8 +635,16 @@ function calculatePopoverLayoutForPlacement(params) {
    * There are cases where the popover is able to satisfy its preferred block
    * size just fine, but not its preferred inline size. This can make the block
    * size meaningless, because it referred to a larger inline size and so may
-   * now be too small and need to scroll. See 打ち付ける.
+   * now be too small and need to scroll.
+   *
+   * So here, we perform yet another layout pass if the given popoverPlacement
+   * can't satisfy the desired inline size.
+   *
+   * TODO: these typings are not resolving, probably because they're
+   * self-referential.
+   *
    * @param {ReturnType<typeof calculatePopoverLayoutForPlacement>} provisionalLayout
+   * @returns {{ type: "unchanged" | "updated", layout: ReturnType<typeof calculatePopoverLayoutForPlacement> }}
    */
   const handleInsufficientInlineSpace = provisionalLayout => {
     const { width, height, maxWidth, maxHeight } = provisionalLayout.popover;
@@ -662,10 +661,6 @@ function calculatePopoverLayoutForPlacement(params) {
             ? Math.floor(maxWidth)
             : Math.floor(maxHeight),
       });
-
-      if (popoverPlacement === 'on the right') {
-        console.log('here yo');
-      }
 
       // Avoid infinite loop
       if (

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -228,13 +228,16 @@ function updatePopover({
   );
   const popoverWritingMode = 'horizontal-tb';
 
-  const { popoverSizeToFitAllResults, popoverSizeToFitFirstResult } =
+  const getPopoverPreferredSizes = () =>
     getPreferredSize({
       hasMultipleResults: results.length > 1,
       popoverMinimumInlineSize,
       blockSizeForShowMoreButton,
       popoverWritingMode,
     });
+
+  const { popoverSizeToFitAllResults, popoverSizeToFitFirstResult } =
+    getPopoverPreferredSizes();
 
   console.log(
     `popoverSizeToFitAllResults ${JSON.stringify(popoverSizeToFitAllResults)}`,
@@ -286,10 +289,14 @@ function updatePopover({
   const layoutToFitAllResults = calculatePopoverLayout({
     ...layoutArgs,
     popoverPreferredSize: popoverSizeToFitAllResults,
+    getPopoverPreferredSize: () =>
+      getPopoverPreferredSizes().popoverSizeToFitAllResults,
   });
   const layoutToFitFirstResult = calculatePopoverLayout({
     ...layoutArgs,
     popoverPreferredSize: popoverSizeToFitFirstResult,
+    getPopoverPreferredSize: () =>
+      getPopoverPreferredSizes().popoverSizeToFitFirstResult,
   });
 
   console.log(
@@ -399,6 +406,7 @@ function updatePopover({
  * @param {number} params.popoverMinimumBlockSize The minimum block size a
  * suggested solution should have.
  * @param {number} params.popoverInsetSize
+ * @param {() => { width: number; height: number; }} params.getPopoverPreferredSize
  */
 function calculatePopoverLayout(params) {
   const {
@@ -472,16 +480,6 @@ function calculatePopoverLayout(params) {
     viewportHeight,
     popoverPlacement: 'on the right',
   });
-
-  // If preferred inline size was unable to be satisfied, then we need to
-  // remeasure using the available max inline size.
-  if (
-    popoverWritingMode === 'horizontal-tb'
-      ? above.popover.width > above.popover.maxWidth
-      : above.popover.height > above.popover.maxHeight
-  ) {
-    // TODO
-  }
 
   const sorted = preferenceOrder
     .map(preference => {
@@ -594,17 +592,20 @@ function calculatePopoverLayout(params) {
 /**
  * @param {Parameters<typeof calculatePopoverLayout>[0] & { popoverPlacement: 'above' | 'below' | 'on the left' | 'on the right'; viewportWidth: number; viewportHeight: number; }} params
  */
-function calculatePopoverLayoutForPlacement({
-  boundingClientRect,
-  clientRect = boundingClientRect,
-  popoverWritingMode,
-  popoverPreferredSize,
-  arrowSize,
-  popoverInsetSize,
-  popoverPlacement,
-  viewportWidth,
-  viewportHeight,
-}) {
+function calculatePopoverLayoutForPlacement(params) {
+  const {
+    boundingClientRect,
+    clientRect = boundingClientRect,
+    popoverWritingMode,
+    popoverPreferredSize,
+    getPopoverPreferredSize,
+    arrowSize,
+    popoverInsetSize,
+    popoverPlacement,
+    viewportWidth,
+    viewportHeight,
+  } = params;
+
   switch (popoverPlacement) {
     case 'above': {
       //        horizontal-tb ltr               horizontal-tb rtl

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -358,50 +358,48 @@ function updatePopover({
 
 /**
  *
- * @param {object} obj
- * @param {DOMRect} obj.boundingClientRect The bounds of the whole highlighted
+ * @param {object} params
+ * @param {DOMRect} params.boundingClientRect The bounds of the whole highlighted
  * range. The popover will avoid this space when laying out.
- * @param {DOMRect} [obj.clientRect] The area within that range that the arrow
+ * @param {DOMRect} [params.clientRect] The area within that range that the arrow
  * should point at. Mostly relevant for when target text spans across multiple
  * lines; defaults to boundingClientRect if not provided.
- * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr"} obj.sourceTextWritingMode
- * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr"} obj.popoverWritingMode
- * @param {{ width: number; height: number }} obj.popoverPreferredSize
- * @param {{ breadth: number; length: number }} obj.arrowSize
- * @param {number} obj.popoverMinimumInlineSize The minimum inline size a
+ * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr"} params.sourceTextWritingMode
+ * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr"} params.popoverWritingMode
+ * @param {{ width: number; height: number }} params.popoverPreferredSize
+ * @param {{ breadth: number; length: number }} params.arrowSize
+ * @param {number} params.popoverMinimumInlineSize The minimum inline size a
  * suggested solution should have.
- * @param {number} obj.popoverMinimumBlockSize The minimum block size a
+ * @param {number} params.popoverMinimumBlockSize The minimum block size a
  * suggested solution should have.
- * @param {number} obj.popoverInsetSize
+ * @param {number} params.popoverInsetSize
  */
-function calculatePopoverLayout({
-  boundingClientRect,
-  clientRect = boundingClientRect,
-  sourceTextWritingMode,
-  popoverWritingMode,
-  popoverPreferredSize,
-  arrowSize,
-  popoverInsetSize,
-  popoverMinimumInlineSize,
-  popoverMinimumBlockSize,
-}) {
+function calculatePopoverLayout(params) {
+  const {
+    boundingClientRect,
+    clientRect = boundingClientRect,
+    sourceTextWritingMode,
+    popoverWritingMode,
+    popoverPreferredSize,
+    popoverInsetSize,
+    popoverMinimumInlineSize,
+    popoverMinimumBlockSize,
+  } = params;
+
   console.log('calculatePopoverLayout', {
     clientRect,
     boundingClientRect,
     popoverPreferredSize,
   });
 
-  const preferredInlineSize =
-    popoverWritingMode === 'horizontal-tb'
-      ? popoverPreferredSize.width
-      : popoverPreferredSize.height;
-  const preferredBlockSize =
-    popoverWritingMode === 'horizontal-tb'
-      ? popoverPreferredSize.height
-      : popoverPreferredSize.width;
-
-  const viewportWidth = window.innerWidth;
-  const viewportHeight = window.innerHeight;
+  // const preferredInlineSize =
+  //   popoverWritingMode === 'horizontal-tb'
+  //     ? popoverPreferredSize.width
+  //     : popoverPreferredSize.height;
+  // const preferredBlockSize =
+  //   popoverWritingMode === 'horizontal-tb'
+  //     ? popoverPreferredSize.height
+  //     : popoverPreferredSize.width;
 
   /**
    * The order of preference as to where the popover should be placed relative
@@ -421,242 +419,55 @@ function calculatePopoverLayout({
         ];
   console.log('preferenceOrder', { preferenceOrder, sourceTextWritingMode });
 
-  //        horizontal-tb ltr               horizontal-tb rtl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃                            ┃   ┃                            ┃
-  // ┃    ┏━━━━━━━┓               ┃   ┃                ┏━━━━━━━┓   ┃
-  // ┃    ┃ abc   ┃               ┃   ┃                ┃   cba ┃   ┃
-  // ┃    ┃ defg  ┃               ┃   ┃                ┃  gfed ┃   ┃
-  // ┃    ┣━━━━━━━┛               ┃   ┃                ┗━━━━━━━┫   ┃
-  // ┃    ⏷                       ┃   ┃                        ⏷   ┃
-  // ┃ abcdefghij                 ┃   ┃                 jihgfedcba ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  //
-  //          vertical-lr                      vertical-rl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃ a h                        ┃   ┃                        h a ┃
-  // ┃ b ┏━━━━━━━┓                ┃   ┃                ┏━━━━━━━┓ b ┃
-  // ┃ c ┃ ac    ┃                ┃   ┃                ┃    ca ┃ c ┃
-  // ┃ d ┃ b     ┃                ┃   ┃                ┃     b ┃ d ┃
-  // ┃ e ┣━━━━━━━┛                ┃   ┃                ┗━━━━━━━┫ e ┃
-  // ┃ f ⏷                        ┃   ┃                        ⏷ f ┃
-  // ┃ g n                        ┃   ┃                        n g ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  const above = {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  const above = calculatePopoverLayoutForPlacement({
+    ...params,
+    viewportWidth,
+    viewportHeight,
     popoverPlacement: 'above',
-    // FIXME: would be nice to ensure the arrow stays within popoverInsetSize,
-    //        as otherwise, when the arrow is at the viewport edge, the popover
-    //        can detach from it.
-    arrow: {
-      x: clientRect.left + clientRect.width / 2 - arrowSize.breadth / 2,
-      y: clientRect.top - arrowSize.length,
-      width: arrowSize.breadth,
-      height: arrowSize.length,
-    },
-    popover: {
-      x: popoverInsetSize,
-      y: popoverInsetSize,
-      width: popoverPreferredSize.width,
-      height: popoverPreferredSize.height,
-      maxWidth: viewportWidth - popoverInsetSize * 2,
-      maxHeight: boundingClientRect.top - popoverInsetSize - arrowSize.length,
-    },
-  };
-  const aboveAdjusted = {
-    popoverPlacement: 'above',
-    arrow: above.arrow,
-    popover: alignAndJustify({
-      popoverPlacement: 'above',
-      horizontalAlign: 'right',
-      verticalAlign: 'bottom',
-      constraints: above.popover,
-      arrowRect: above.arrow,
-      arrowOverhang: 20,
-    }),
-  };
-
-  //        horizontal-tb ltr               horizontal-tb rtl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃ abcdefghij                 ┃   ┃                 jihgfedcba ┃
-  // ┃    ⏶                       ┃   ┃                        ⏶   ┃
-  // ┃    ┣━━━━━━━┓               ┃   ┃                ┏━━━━━━━┫   ┃
-  // ┃    ┃ abc   ┃               ┃   ┃                ┃   cba ┃   ┃
-  // ┃    ┃ defg  ┃               ┃   ┃                ┃  gfed ┃   ┃
-  // ┃    ┗━━━━━━━┛               ┃   ┃                ┗━━━━━━━┛   ┃
-  // ┃                            ┃   ┃                            ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  //
-  //          vertical-lr                      vertical-rl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃ a i                        ┃   ┃                        i a ┃
-  // ┃ b ⏶                        ┃   ┃                        ⏶ b ┃
-  // ┃ c ┣━━━━━━━┓                ┃   ┃                ┏━━━━━━━┫ c ┃
-  // ┃ d ┃ ac    ┃                ┃   ┃                ┃    ca ┃ d ┃
-  // ┃ e ┃ b     ┃                ┃   ┃                ┃     b ┃ e ┃
-  // ┃ f ┗━━━━━━━┛                ┃   ┃                ┗━━━━━━━┛ f ┃
-  // ┃ g o                        ┃   ┃                        o g ┃
-  // ┃ h p                        ┃   ┃                        p h ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  const below = {
+  });
+  const below = calculatePopoverLayoutForPlacement({
+    ...params,
+    viewportWidth,
+    viewportHeight,
     popoverPlacement: 'below',
-    arrow: {
-      x: above.arrow.x,
-      y: clientRect.bottom,
-      width: arrowSize.breadth,
-      height: arrowSize.length,
-    },
-    popover: {
-      x: popoverInsetSize,
-      y: boundingClientRect.bottom + arrowSize.length,
-      width: popoverPreferredSize.width,
-      height: popoverPreferredSize.height,
-      maxWidth: viewportWidth - popoverInsetSize * 2,
-      maxHeight:
-        viewportHeight -
-        boundingClientRect.bottom -
-        popoverInsetSize -
-        arrowSize.length,
-    },
-  };
-  const belowAdjusted = {
-    popoverPlacement: 'below',
-    arrow: below.arrow,
-    popover: alignAndJustify({
-      popoverPlacement: 'below',
-      horizontalAlign: 'right',
-      verticalAlign: 'top',
-      constraints: below.popover,
-      arrowRect: below.arrow,
-      arrowOverhang: 20,
-    }),
-  };
-
-  //        horizontal-tb ltr               horizontal-tb rtl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
-  // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
-  // ┃              ┏━━━━━━━┳⏵abc ┃   ┃              ┏━━━━━━━┳⏵cba ┃
-  // ┃              ┃ abc   ┃ abc ┃   ┃              ┃   cba ┃ cba ┃
-  // ┃              ┃ defg  ┃ abc ┃   ┃              ┃  gfed ┃ cba ┃
-  // ┃              ┗━━━━━━━┛ abc ┃   ┃              ┗━━━━━━━┛ cba ┃
-  // ┃                            ┃   ┃                            ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  //
-  //          vertical-lr                      vertical-rl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃ a a a a a a a a a a a a a  ┃   ┃                          a ┃
-  // ┃ b b b b b b b b b b b b b  ┃   ┃                          b ┃
-  // ┃ c c c c c c c ┏━━━━━━━┳⏵c  ┃   ┃                ┏━━━━━━━┳⏵c ┃
-  // ┃ d d d d d d d ┃ ac    ┃ d  ┃   ┃                ┃    ca ┃ d ┃
-  // ┃ e e e e e e e ┃ b     ┃    ┃   ┃                ┃     b ┃ e ┃
-  // ┃ f f f f f f f ┗━━━━━━━┛    ┃   ┃                ┗━━━━━━━┛ f ┃
-  // ┃ g g g g g g g g g g g g    ┃   ┃                            ┃
-  // ┃ h h h h h h h h h h h h    ┃   ┃                            ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  const toLeft = {
+  });
+  const toLeft = calculatePopoverLayoutForPlacement({
+    ...params,
+    viewportWidth,
+    viewportHeight,
     popoverPlacement: 'on the left',
-    arrow: {
-      x: clientRect.left - arrowSize.length,
-      y: clientRect.top + clientRect.height / 2 - arrowSize.breadth / 2,
-      width: arrowSize.length,
-      height: arrowSize.breadth,
-    },
-    popover: {
-      x: popoverInsetSize,
-      y: popoverInsetSize,
-      width: popoverPreferredSize.width,
-      height: popoverPreferredSize.height,
-      maxWidth: boundingClientRect.left - popoverInsetSize - arrowSize.length,
-      maxHeight: viewportHeight - popoverInsetSize * 2,
-    },
-  };
-  const toLeftAdjusted = {
-    popoverPlacement: 'on the left',
-    arrow: toLeft.arrow,
-    popover: alignAndJustify({
-      popoverPlacement: 'on the left',
-      horizontalAlign: 'right',
-      verticalAlign: 'bottom',
-      constraints: toLeft.popover,
-      arrowRect: toLeft.arrow,
-      arrowOverhang: 20,
-    }),
-  };
+  });
+  const toRight = calculatePopoverLayoutForPlacement({
+    ...params,
+    viewportWidth,
+    viewportHeight,
+    popoverPlacement: 'on the right',
+  });
 
-  //        horizontal-tb ltr               horizontal-tb rtl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
-  // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
-  // ┃ abc⏴┳━━━━━━━┓              ┃   ┃ zyx⏴┳━━━━━━━┓ lkjihgfedcba ┃
-  // ┃ abc ┃ abc   ┃              ┃   ┃ zyx ┃ edcba ┃          cba ┃
-  // ┃ abc ┃ defg  ┃              ┃   ┃ zyx ┃    gf ┃              ┃
-  // ┃ abc ┗━━━━━━━┛              ┃   ┃ zyx ┗━━━━━━━┛              ┃
-  // ┃                            ┃   ┃                            ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  //
-  //          vertical-lr                      vertical-rl
-  // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  // ┃ a a                        ┃   ┃   a a a a a a  a a a a a a ┃
-  // ┃ b b                        ┃   ┃   b b b b b b  b b b b b b ┃
-  // ┃ c c ⏴┳━━━━━━━┓             ┃   ┃   c ⏴┳━━━━━━━┓ c c c c c c ┃
-  // ┃ d d  ┃ ac    ┃             ┃   ┃   d  ┃    ca ┃ d d d d d d ┃
-  // ┃ e e  ┃ b     ┃             ┃   ┃   e  ┃     b ┃ e e e e e e ┃
-  // ┃ f f  ┗━━━━━━━┛             ┃   ┃      ┗━━━━━━━┛ f f f f f f ┃
-  // ┃ g                          ┃   ┃     g g g g g  g g g g g g ┃
-  // ┃ h                          ┃   ┃     h h h h h  h h h h h h ┃
-  // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-  const toRightArrow = {
-    x: clientRect.right,
-    y: toLeft.arrow.y,
-    width: arrowSize.length,
-    height: arrowSize.breadth,
-  };
-  const toRight = {
-    popoverPlacement: 'on the right',
-    arrow: toRightArrow,
-    popover: {
-      // We have an interesting case with vertical-rl when a word flows onto a
-      // new line such that the start of the word is clickable within the
-      // viewport, yet the end of the word extends out of the viewport. We've
-      // generally chosen to point at the end of the word, but in this rare case
-      // it might make more sense to point at the start just to stay within the
-      // viewport. However, it's okay to just do what's easiest.
-      x: Math.max(popoverInsetSize, toRightArrow.x + toRightArrow.width),
-      y: popoverInsetSize,
-      width: popoverPreferredSize.width,
-      height: popoverPreferredSize.height,
-      maxWidth:
-        viewportWidth -
-        boundingClientRect.right -
-        popoverInsetSize -
-        arrowSize.length,
-      maxHeight: viewportHeight - popoverInsetSize * 2,
-    },
-  };
-  const toRightAdjusted = {
-    popoverPlacement: 'on the right',
-    arrow: toRight.arrow,
-    popover: alignAndJustify({
-      popoverPlacement: 'on the right',
-      horizontalAlign: 'left',
-      verticalAlign: 'bottom',
-      constraints: toRight.popover,
-      arrowRect: toRight.arrow,
-      arrowOverhang: 20,
-    }),
-  };
+  // If preferred inline size was unable to be satisfied, then we need to
+  // remeasure using the available max inline size.
+  if (
+    popoverWritingMode === 'horizontal-tb'
+      ? above.popover.width > above.popover.maxWidth
+      : above.popover.height > above.popover.maxHeight
+  ) {
+    // TODO
+  }
 
   const sorted = preferenceOrder
     .map(preference => {
       switch (preference) {
         case 'above':
-          return aboveAdjusted;
+          return above;
         case 'below':
-          return belowAdjusted;
+          return below;
         case 'on the left':
-          return toLeftAdjusted;
+          return toLeft;
         case 'on the right':
-          return toRightAdjusted;
+          return toRight;
       }
     })
     .sort((a, b) => {
@@ -747,11 +558,266 @@ function calculatePopoverLayout({
   return {
     best: sorted[0],
     sorted,
-    aboveAdjusted: above,
-    belowAdjusted: below,
-    toLeftAdjusted: toLeft,
-    toRightAdjusted: toRight,
+    above,
+    below,
+    toLeft,
+    toRight,
   };
+}
+
+/**
+ * @param {Parameters<typeof calculatePopoverLayout>[0] & { popoverPlacement: 'above' | 'below' | 'on the left' | 'on the right'; viewportWidth: number; viewportHeight: number; }} params
+ */
+function calculatePopoverLayoutForPlacement({
+  boundingClientRect,
+  clientRect = boundingClientRect,
+  popoverPreferredSize,
+  arrowSize,
+  popoverInsetSize,
+  popoverPlacement,
+  viewportWidth,
+  viewportHeight,
+}) {
+  switch (popoverPlacement) {
+    case 'above': {
+      //        horizontal-tb ltr               horizontal-tb rtl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃                            ┃   ┃                            ┃
+      // ┃    ┏━━━━━━━┓               ┃   ┃                ┏━━━━━━━┓   ┃
+      // ┃    ┃ abc   ┃               ┃   ┃                ┃   cba ┃   ┃
+      // ┃    ┃ defg  ┃               ┃   ┃                ┃  gfed ┃   ┃
+      // ┃    ┣━━━━━━━┛               ┃   ┃                ┗━━━━━━━┫   ┃
+      // ┃    ⏷                       ┃   ┃                        ⏷   ┃
+      // ┃ abcdefghij                 ┃   ┃                 jihgfedcba ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      //
+      //          vertical-lr                      vertical-rl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃ a h                        ┃   ┃                        h a ┃
+      // ┃ b ┏━━━━━━━┓                ┃   ┃                ┏━━━━━━━┓ b ┃
+      // ┃ c ┃ ac    ┃                ┃   ┃                ┃    ca ┃ c ┃
+      // ┃ d ┃ b     ┃                ┃   ┃                ┃     b ┃ d ┃
+      // ┃ e ┣━━━━━━━┛                ┃   ┃                ┗━━━━━━━┫ e ┃
+      // ┃ f ⏷                        ┃   ┃                        ⏷ f ┃
+      // ┃ g n                        ┃   ┃                        n g ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      const above = {
+        popoverPlacement: 'above',
+        // FIXME: would be nice to ensure the arrow stays within
+        //        popoverInsetSize, as otherwise, when the arrow is at the
+        //        viewport edge, the popover can detach from it.
+        arrow: {
+          x: clientRect.left + clientRect.width / 2 - arrowSize.breadth / 2,
+          y: clientRect.top - arrowSize.length,
+          width: arrowSize.breadth,
+          height: arrowSize.length,
+        },
+        popover: {
+          x: popoverInsetSize,
+          y: popoverInsetSize,
+          width: popoverPreferredSize.width,
+          height: popoverPreferredSize.height,
+          maxWidth: viewportWidth - popoverInsetSize * 2,
+          maxHeight:
+            boundingClientRect.top - popoverInsetSize - arrowSize.length,
+        },
+      };
+      const aboveAdjusted = {
+        popoverPlacement: 'above',
+        arrow: above.arrow,
+        popover: alignAndJustify({
+          popoverPlacement: 'above',
+          horizontalAlign: 'right',
+          verticalAlign: 'bottom',
+          constraints: above.popover,
+          arrowRect: above.arrow,
+          arrowOverhang: 20,
+        }),
+      };
+
+      return aboveAdjusted;
+    }
+    case 'below': {
+      //        horizontal-tb ltr               horizontal-tb rtl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃ abcdefghij                 ┃   ┃                 jihgfedcba ┃
+      // ┃    ⏶                       ┃   ┃                        ⏶   ┃
+      // ┃    ┣━━━━━━━┓               ┃   ┃                ┏━━━━━━━┫   ┃
+      // ┃    ┃ abc   ┃               ┃   ┃                ┃   cba ┃   ┃
+      // ┃    ┃ defg  ┃               ┃   ┃                ┃  gfed ┃   ┃
+      // ┃    ┗━━━━━━━┛               ┃   ┃                ┗━━━━━━━┛   ┃
+      // ┃                            ┃   ┃                            ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      //
+      //          vertical-lr                      vertical-rl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃ a i                        ┃   ┃                        i a ┃
+      // ┃ b ⏶                        ┃   ┃                        ⏶ b ┃
+      // ┃ c ┣━━━━━━━┓                ┃   ┃                ┏━━━━━━━┫ c ┃
+      // ┃ d ┃ ac    ┃                ┃   ┃                ┃    ca ┃ d ┃
+      // ┃ e ┃ b     ┃                ┃   ┃                ┃     b ┃ e ┃
+      // ┃ f ┗━━━━━━━┛                ┃   ┃                ┗━━━━━━━┛ f ┃
+      // ┃ g o                        ┃   ┃                        o g ┃
+      // ┃ h p                        ┃   ┃                        p h ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      const below = {
+        popoverPlacement: 'below',
+        arrow: {
+          x: clientRect.left + clientRect.width / 2 - arrowSize.breadth / 2,
+          y: clientRect.bottom,
+          width: arrowSize.breadth,
+          height: arrowSize.length,
+        },
+        popover: {
+          x: popoverInsetSize,
+          y: boundingClientRect.bottom + arrowSize.length,
+          width: popoverPreferredSize.width,
+          height: popoverPreferredSize.height,
+          maxWidth: viewportWidth - popoverInsetSize * 2,
+          maxHeight:
+            viewportHeight -
+            boundingClientRect.bottom -
+            popoverInsetSize -
+            arrowSize.length,
+        },
+      };
+      const belowAdjusted = {
+        popoverPlacement: 'below',
+        arrow: below.arrow,
+        popover: alignAndJustify({
+          popoverPlacement: 'below',
+          horizontalAlign: 'right',
+          verticalAlign: 'top',
+          constraints: below.popover,
+          arrowRect: below.arrow,
+          arrowOverhang: 20,
+        }),
+      };
+
+      return belowAdjusted;
+    }
+    case 'on the left': {
+      //        horizontal-tb ltr               horizontal-tb rtl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
+      // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
+      // ┃              ┏━━━━━━━┳⏵abc ┃   ┃              ┏━━━━━━━┳⏵cba ┃
+      // ┃              ┃ abc   ┃ abc ┃   ┃              ┃   cba ┃ cba ┃
+      // ┃              ┃ defg  ┃ abc ┃   ┃              ┃  gfed ┃ cba ┃
+      // ┃              ┗━━━━━━━┛ abc ┃   ┃              ┗━━━━━━━┛ cba ┃
+      // ┃                            ┃   ┃                            ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      //
+      //          vertical-lr                      vertical-rl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃ a a a a a a a a a a a a a  ┃   ┃                          a ┃
+      // ┃ b b b b b b b b b b b b b  ┃   ┃                          b ┃
+      // ┃ c c c c c c c ┏━━━━━━━┳⏵c  ┃   ┃                ┏━━━━━━━┳⏵c ┃
+      // ┃ d d d d d d d ┃ ac    ┃ d  ┃   ┃                ┃    ca ┃ d ┃
+      // ┃ e e e e e e e ┃ b     ┃    ┃   ┃                ┃     b ┃ e ┃
+      // ┃ f f f f f f f ┗━━━━━━━┛    ┃   ┃                ┗━━━━━━━┛ f ┃
+      // ┃ g g g g g g g g g g g g    ┃   ┃                            ┃
+      // ┃ h h h h h h h h h h h h    ┃   ┃                            ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      const toLeft = {
+        popoverPlacement: 'on the left',
+        arrow: {
+          x: clientRect.left - arrowSize.length,
+          y: clientRect.top + clientRect.height / 2 - arrowSize.breadth / 2,
+          width: arrowSize.length,
+          height: arrowSize.breadth,
+        },
+        popover: {
+          x: popoverInsetSize,
+          y: popoverInsetSize,
+          width: popoverPreferredSize.width,
+          height: popoverPreferredSize.height,
+          maxWidth:
+            boundingClientRect.left - popoverInsetSize - arrowSize.length,
+          maxHeight: viewportHeight - popoverInsetSize * 2,
+        },
+      };
+      const toLeftAdjusted = {
+        popoverPlacement: 'on the left',
+        arrow: toLeft.arrow,
+        popover: alignAndJustify({
+          popoverPlacement: 'on the left',
+          horizontalAlign: 'right',
+          verticalAlign: 'bottom',
+          constraints: toLeft.popover,
+          arrowRect: toLeft.arrow,
+          arrowOverhang: 20,
+        }),
+      };
+      return toLeftAdjusted;
+    }
+    case 'on the right': {
+      //        horizontal-tb ltr               horizontal-tb rtl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
+      // ┃ abcdefghijklmnopqrstuvwxyz ┃   ┃ zyxwvutsrqponmlkjihgfedcba ┃
+      // ┃ abc⏴┳━━━━━━━┓              ┃   ┃ zyx⏴┳━━━━━━━┓ lkjihgfedcba ┃
+      // ┃ abc ┃ abc   ┃              ┃   ┃ zyx ┃ edcba ┃          cba ┃
+      // ┃ abc ┃ defg  ┃              ┃   ┃ zyx ┃    gf ┃              ┃
+      // ┃ abc ┗━━━━━━━┛              ┃   ┃ zyx ┗━━━━━━━┛              ┃
+      // ┃                            ┃   ┃                            ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      //
+      //          vertical-lr                      vertical-rl
+      // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓   ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+      // ┃ a a                        ┃   ┃   a a a a a a  a a a a a a ┃
+      // ┃ b b                        ┃   ┃   b b b b b b  b b b b b b ┃
+      // ┃ c c ⏴┳━━━━━━━┓             ┃   ┃   c ⏴┳━━━━━━━┓ c c c c c c ┃
+      // ┃ d d  ┃ ac    ┃             ┃   ┃   d  ┃    ca ┃ d d d d d d ┃
+      // ┃ e e  ┃ b     ┃             ┃   ┃   e  ┃     b ┃ e e e e e e ┃
+      // ┃ f f  ┗━━━━━━━┛             ┃   ┃      ┗━━━━━━━┛ f f f f f f ┃
+      // ┃ g                          ┃   ┃     g g g g g  g g g g g g ┃
+      // ┃ h                          ┃   ┃     h h h h h  h h h h h h ┃
+      // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+      const toRightArrow = {
+        x: clientRect.right,
+        y: clientRect.top + clientRect.height / 2 - arrowSize.breadth / 2,
+        width: arrowSize.length,
+        height: arrowSize.breadth,
+      };
+      const toRight = {
+        popoverPlacement: 'on the right',
+        arrow: toRightArrow,
+        popover: {
+          // We have an interesting case with vertical-rl when a word flows onto
+          // a new line such that the start of the word is clickable within the
+          // viewport, yet the end of the word extends out of the viewport.
+          // We've generally chosen to point at the end of the word, but in this
+          // rare case it might make more sense to point at the start just to
+          // stay within the viewport. However, it's okay to just do what's
+          // easiest.
+          x: Math.max(popoverInsetSize, toRightArrow.x + toRightArrow.width),
+          y: popoverInsetSize,
+          width: popoverPreferredSize.width,
+          height: popoverPreferredSize.height,
+          maxWidth:
+            viewportWidth -
+            boundingClientRect.right -
+            popoverInsetSize -
+            arrowSize.length,
+          maxHeight: viewportHeight - popoverInsetSize * 2,
+        },
+      };
+      const toRightAdjusted = {
+        popoverPlacement: 'on the right',
+        arrow: toRight.arrow,
+        popover: alignAndJustify({
+          popoverPlacement: 'on the right',
+          horizontalAlign: 'left',
+          verticalAlign: 'bottom',
+          constraints: toRight.popover,
+          arrowRect: toRight.arrow,
+          arrowOverhang: 20,
+        }),
+      };
+      return toRightAdjusted;
+    }
+  }
 }
 
 /**

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -225,6 +225,20 @@ function updatePopover({
       ) || '0px'
     ).split('px')[0],
   );
+  const popoverMinimumInlineSize = parseFloat(
+    (
+      getComputedStyle(popover).getPropertyValue(
+        '--paranovel-popover-minimum-inline-size',
+      ) || '0px'
+    ).split('px')[0],
+  );
+  const popoverMinimumBlockSize = parseFloat(
+    (
+      getComputedStyle(popover).getPropertyValue(
+        '--paranovel-popover-minimum-block-size',
+      ) || '0px'
+    ).split('px')[0],
+  );
 
   /** @type {Parameters<typeof calculatePopoverLayout>[0]}  */
   const layoutArgs = {
@@ -237,6 +251,8 @@ function updatePopover({
       length: Math.ceil((13 / 15) * 20),
     },
     popoverInsetSize,
+    popoverMinimumInlineSize,
+    popoverMinimumBlockSize,
   };
 
   const layoutToFitAllResults = calculatePopoverLayout({
@@ -276,10 +292,6 @@ function updatePopover({
     popover.style.display = display;
   };
 
-  // FIXME: Clicking text on the left of a vertical-tb passage when there's more
-  // than an arrow's worth of space to the left of it will often result in
-  // "on the left" being selected despite only having a slither of space
-  // available.
   const bestPopoverPlacementToFitFirstResult =
     layoutToFitFirstResult.best.popoverPlacement;
   setPopoverStyle(layoutToFitFirstResult.best);
@@ -354,6 +366,10 @@ function updatePopover({
  * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr"} obj.popoverWritingMode
  * @param {{ width: number; height: number }} obj.popoverPreferredSize
  * @param {{ breadth: number; length: number }} obj.arrowSize
+ * @param {number} obj.popoverMinimumInlineSize The minimum inline size a
+ * suggested solution should have.
+ * @param {number} obj.popoverMinimumBlockSize The minimum block size a
+ * suggested solution should have.
  * @param {number} obj.popoverInsetSize
  */
 function calculatePopoverLayout({
@@ -364,6 +380,8 @@ function calculatePopoverLayout({
   popoverPreferredSize,
   arrowSize,
   popoverInsetSize,
+  popoverMinimumInlineSize,
+  popoverMinimumBlockSize,
 }) {
   console.log('calculatePopoverLayout', {
     clientRect,
@@ -651,6 +669,7 @@ function calculatePopoverLayout({
       // If they both have an arrow out of bounds, continue to the next check.
       if (a.arrow.x < popoverInsetSize || a.arrow.y < popoverInsetSize) {
         if (b.arrow.x >= popoverInsetSize || b.arrow.y >= popoverInsetSize) {
+          console.log('Case 1a: sorting B_BEFORE_A', { a, b });
           return B_BEFORE_A;
         } else {
           // They're both out of bounds. We could sort by the one that's least
@@ -658,23 +677,69 @@ function calculatePopoverLayout({
           // algorithm instead.
         }
       } else if (b.arrow.x < popoverInsetSize || b.arrow.y < popoverInsetSize) {
+        console.log('Case 1b: sorting A_BEFORE_B', { a, b });
         return A_BEFORE_B;
       }
 
-      const aFits =
+      const aFitsAvailableArea =
         a.popover.width <= a.popover.maxWidth &&
         a.popover.height <= a.popover.maxHeight;
-      const bFits =
+      const bFitsAvailableArea =
         b.popover.width <= b.popover.maxWidth &&
         b.popover.height <= b.popover.maxHeight;
 
-      return aFits
-        ? bFits
-          ? NO_CHANGE
-          : A_BEFORE_B
-        : bFits
-        ? B_BEFORE_A
-        : NO_CHANGE;
+      if (aFitsAvailableArea && !bFitsAvailableArea) {
+        console.log('Case 2a: sorting A_BEFORE_B', { a, b });
+        return A_BEFORE_B;
+      }
+
+      if (bFitsAvailableArea && !aFitsAvailableArea) {
+        console.log('Case 2b: sorting B_BEFORE_A', { a, b });
+        return B_BEFORE_A;
+      }
+
+      const aInlineSize =
+        popoverWritingMode === 'horizontal-tb'
+          ? Math.min(a.popover.width, a.popover.maxWidth)
+          : Math.min(a.popover.height, a.popover.maxHeight);
+      const bInlineSize =
+        popoverWritingMode === 'horizontal-tb'
+          ? Math.min(b.popover.width, b.popover.maxWidth)
+          : Math.min(b.popover.height, b.popover.maxHeight);
+      const aBlockSize =
+        popoverWritingMode === 'horizontal-tb'
+          ? Math.min(a.popover.height, a.popover.maxHeight)
+          : Math.min(a.popover.width, a.popover.maxWidth);
+      const bBlockSize =
+        popoverWritingMode === 'horizontal-tb'
+          ? Math.min(b.popover.height, b.popover.maxHeight)
+          : Math.min(b.popover.width, b.popover.maxWidth);
+
+      const aIsAdequatelyLargeInline = aInlineSize >= popoverMinimumInlineSize;
+      const bIsAdequatelyLargeInline = bInlineSize >= popoverMinimumInlineSize;
+
+      if (aIsAdequatelyLargeInline && !bIsAdequatelyLargeInline) {
+        return A_BEFORE_B;
+      }
+
+      if (bIsAdequatelyLargeInline && !aIsAdequatelyLargeInline) {
+        return B_BEFORE_A;
+      }
+
+      const aIsAdequatelyLargeBlock = aBlockSize >= popoverMinimumBlockSize;
+      const bIsAdequatelyLargeBlock = bBlockSize >= popoverMinimumBlockSize;
+
+      if (aIsAdequatelyLargeBlock && !bIsAdequatelyLargeBlock) {
+        return A_BEFORE_B;
+      }
+
+      if (bIsAdequatelyLargeBlock && !aIsAdequatelyLargeBlock) {
+        return B_BEFORE_A;
+      }
+
+      console.log('Case 3: sorting NO_CHANGE', { a, b });
+
+      return NO_CHANGE;
     });
 
   return {

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -161,6 +161,9 @@ function updatePopover({
    * @param {boolean} params.hasMultipleResults
    * @param {number} params.popoverMinimumInlineSize
    * @param {number} params.blockSizeForShowMoreButton
+   * @param {number} [params.maxInlineSize] The max inline size. Defaults to the
+   * inline viewport size minus the inset size (or the configured max readable
+   * inline size, if that is lower).
    * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr"} params.popoverWritingMode
    */
   const getPreferredSize = ({
@@ -168,32 +171,51 @@ function updatePopover({
     popoverMinimumInlineSize,
     blockSizeForShowMoreButton,
     popoverWritingMode,
+    maxInlineSize,
   }) => {
     popover.style.left = 'var(--paranovel-popover-inset-size)';
     popover.style.top = 'var(--paranovel-popover-inset-size)';
     popover.style.boxSizing = 'border-box';
     popover.style.display = 'block';
-    popover.style.visibility = 'hidden';
+    // popover.style.visibility = 'hidden';
+    popover.style.visibility = 'visible';
 
     // 'auto' may produce a floating-point number, while clientWidth and
     // clientHeight produce a floored version of that number
     popover.style.inlineSize = 'auto';
     popover.style.minInlineSize = `${popoverMinimumInlineSize}px`;
-    popover.style.maxInlineSize =
-      'round(down, min(calc(100vi - var(--paranovel-popover-inset-size) * 2), var(--paranovel-max-readable-inline-size)), 1px)';
+    popover.style.maxInlineSize = maxInlineSize
+      ? `${maxInlineSize}px`
+      : 'round(down, min(calc(100vi - var(--paranovel-popover-inset-size) * 2), var(--paranovel-max-readable-inline-size)), 1px)';
     popover.style.blockSize = 'auto';
     // popover.style.maxBlockSize = '50%';
 
+    const popoverMaxInlineSize = parseFloat(
+      getComputedStyle(popover).maxInlineSize.split('px')[0],
+    );
+    console.log('!! popoverMaxInlineSize', {
+      popoverMaxInlineSize,
+      clientWidth: popover.clientWidth,
+    });
+
     // FIXME: clientHeight/clientWidth floor the true values, so if you take
     // their values as written, you may end up underestimating the size needed
-    // to fit content. For the time being, we add an extra pixel to each size to
-    // prefer overestimating.
+    // to fit content. We add an extra pixel to each size to prefer
+    // overestimating, and clamp it to the computed maxInlineSize to avoid the
+    // added pixel breaking the original constraints. This is less of a concern
+    // for the block size, where an overestimate does not affect text flow.
     //
     // There may be other sub-pixel values to track down elsewhere in our
     // measurements (e.g. scroll position and viewport size).
     const popoverSizeToFitAllResults = {
-      width: popover.clientWidth + 1,
-      height: popover.clientHeight + 1,
+      width:
+        popoverWritingMode === 'horizontal-tb'
+          ? Math.min(popover.clientWidth + 1, popoverMaxInlineSize)
+          : popover.clientWidth + 1,
+      height:
+        popoverWritingMode === 'horizontal-tb'
+          ? popover.clientHeight + 1
+          : Math.min(popover.clientHeight + 1, popoverMaxInlineSize),
     };
 
     // When there are multiple results to show, we size the popover to fit just
@@ -203,8 +225,14 @@ function updatePopover({
     if (hasMultipleResults) {
       popover.classList.add('size-to-first-result-container');
       popoverSizeToFitFirstResult = {
-        width: popover.clientWidth + 1,
-        height: popover.clientHeight + 1,
+        width:
+          popoverWritingMode === 'horizontal-tb'
+            ? Math.min(popover.clientWidth + 1, popoverMaxInlineSize)
+            : popover.clientWidth + 1,
+        height:
+          popoverWritingMode === 'horizontal-tb'
+            ? popover.clientHeight + 1
+            : Math.min(popover.clientHeight + 1, popoverMaxInlineSize),
       };
       if (popoverWritingMode === 'horizontal-tb') {
         popoverSizeToFitFirstResult.height += blockSizeForShowMoreButton;
@@ -228,12 +256,19 @@ function updatePopover({
   );
   const popoverWritingMode = 'horizontal-tb';
 
-  const getPopoverPreferredSizes = () =>
+  /**
+   * @param {object} [params]
+   * @param {number} [params.maxInlineSize] The max inline size. Defaults to the
+   * inline viewport size minus the inset size (or the configured max readable
+   * inline size, if that is lower).
+   */
+  const getPopoverPreferredSizes = ({ maxInlineSize } = {}) =>
     getPreferredSize({
       hasMultipleResults: results.length > 1,
       popoverMinimumInlineSize,
       blockSizeForShowMoreButton,
       popoverWritingMode,
+      maxInlineSize,
     });
 
   const { popoverSizeToFitAllResults, popoverSizeToFitFirstResult } =
@@ -289,19 +324,19 @@ function updatePopover({
   const layoutToFitAllResults = calculatePopoverLayout({
     ...layoutArgs,
     popoverPreferredSize: popoverSizeToFitAllResults,
-    getPopoverPreferredSize: () =>
-      getPopoverPreferredSizes().popoverSizeToFitAllResults,
+    getPopoverPreferredSize: params =>
+      getPopoverPreferredSizes(params).popoverSizeToFitAllResults,
   });
   const layoutToFitFirstResult = calculatePopoverLayout({
     ...layoutArgs,
     popoverPreferredSize: popoverSizeToFitFirstResult,
-    getPopoverPreferredSize: () =>
-      getPopoverPreferredSizes().popoverSizeToFitFirstResult,
+    getPopoverPreferredSize: params =>
+      getPopoverPreferredSizes(params).popoverSizeToFitFirstResult,
   });
 
   console.log(
     `Got best popoverLayout ${JSON.stringify(
-      layoutToFitFirstResult.best.popoverLayout,
+      layoutToFitFirstResult.best.popover,
     )}, given clientRect`,
     clientRect,
   );
@@ -406,7 +441,7 @@ function updatePopover({
  * @param {number} params.popoverMinimumBlockSize The minimum block size a
  * suggested solution should have.
  * @param {number} params.popoverInsetSize
- * @param {() => { width: number; height: number; }} params.getPopoverPreferredSize
+ * @param {(params: { maxInlineSize?: number }) => { width: number; height: number; }} params.getPopoverPreferredSize
  */
 function calculatePopoverLayout(params) {
   const {
@@ -606,6 +641,51 @@ function calculatePopoverLayoutForPlacement(params) {
     viewportHeight,
   } = params;
 
+  /**
+   * There are cases where the popover is able to satisfy its preferred block
+   * size just fine, but not its preferred inline size. This can make the block
+   * size meaningless, because it referred to a larger inline size and so may
+   * now be too small and need to scroll. See 打ち付ける.
+   * @param {ReturnType<typeof calculatePopoverLayoutForPlacement>} provisionalLayout
+   */
+  const handleInsufficientInlineSpace = provisionalLayout => {
+    const { width, height, maxWidth, maxHeight } = provisionalLayout.popover;
+
+    if (
+      popoverWritingMode === 'horizontal-tb'
+        ? width > maxWidth
+        : height > maxHeight
+    ) {
+      // Lay out again
+      const popoverPreferredSize = getPopoverPreferredSize({
+        maxInlineSize:
+          popoverWritingMode === 'horizontal-tb'
+            ? Math.floor(maxWidth)
+            : Math.floor(maxHeight),
+      });
+
+      if (popoverPlacement === 'on the right') {
+        console.log('here yo');
+      }
+
+      // Avoid infinite loop
+      if (
+        popoverWritingMode === 'horizontal-tb'
+          ? popoverPreferredSize.width >= width
+          : popoverPreferredSize.height >= height
+      ) {
+        return provisionalLayout;
+      }
+
+      return calculatePopoverLayoutForPlacement({
+        ...params,
+        popoverPreferredSize,
+      });
+    }
+
+    return provisionalLayout;
+  };
+
   switch (popoverPlacement) {
     case 'above': {
       //        horizontal-tb ltr               horizontal-tb rtl
@@ -629,7 +709,7 @@ function calculatePopoverLayoutForPlacement(params) {
       // ┃ f ⏷                        ┃   ┃                        ⏷ f ┃
       // ┃ g n                        ┃   ┃                        n g ┃
       // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-      const above = {
+      let above = {
         popoverPlacement: 'above',
         // FIXME: would be nice to ensure the arrow stays within
         //        popoverInsetSize, as otherwise, when the arrow is at the
@@ -651,18 +731,7 @@ function calculatePopoverLayoutForPlacement(params) {
         },
       };
 
-      // FIXME: There are cases where the popover is able to satisfy its
-      // preferred block size just fine, but not its preferred inline size. This
-      // can make the block size meaningless, because it referred to a larger
-      // inline size and so may now be too small and need to scroll. See
-      // 打ち付ける.
-      if (
-        popoverWritingMode === 'horizontal-tb'
-          ? above.popover.width > above.popover.maxWidth
-          : above.popover.height > above.popover.maxHeight
-      ) {
-        // Lay out again
-      }
+      above = handleInsufficientInlineSpace(above);
 
       const aboveAdjusted = {
         popoverPlacement: 'above',
@@ -702,7 +771,7 @@ function calculatePopoverLayoutForPlacement(params) {
       // ┃ g o                        ┃   ┃                        o g ┃
       // ┃ h p                        ┃   ┃                        p h ┃
       // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-      const below = {
+      let below = {
         popoverPlacement: 'below',
         arrow: {
           x: clientRect.left + clientRect.width / 2 - arrowSize.breadth / 2,
@@ -723,6 +792,9 @@ function calculatePopoverLayoutForPlacement(params) {
             arrowSize.length,
         },
       };
+
+      below = handleInsufficientInlineSpace(below);
+
       const belowAdjusted = {
         popoverPlacement: 'below',
         arrow: below.arrow,
@@ -761,7 +833,7 @@ function calculatePopoverLayoutForPlacement(params) {
       // ┃ g g g g g g g g g g g g    ┃   ┃                            ┃
       // ┃ h h h h h h h h h h h h    ┃   ┃                            ┃
       // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-      const toLeft = {
+      let toLeft = {
         popoverPlacement: 'on the left',
         arrow: {
           x: clientRect.left - arrowSize.length,
@@ -779,6 +851,9 @@ function calculatePopoverLayoutForPlacement(params) {
           maxHeight: viewportHeight - popoverInsetSize * 2,
         },
       };
+
+      toLeft = handleInsufficientInlineSpace(toLeft);
+
       const toLeftAdjusted = {
         popoverPlacement: 'on the left',
         arrow: toLeft.arrow,
@@ -822,7 +897,7 @@ function calculatePopoverLayoutForPlacement(params) {
         width: arrowSize.length,
         height: arrowSize.breadth,
       };
-      const toRight = {
+      let toRight = {
         popoverPlacement: 'on the right',
         arrow: toRightArrow,
         popover: {
@@ -845,6 +920,9 @@ function calculatePopoverLayoutForPlacement(params) {
           maxHeight: viewportHeight - popoverInsetSize * 2,
         },
       };
+
+      toRight = handleInsufficientInlineSpace(toRight);
+
       const toRightAdjusted = {
         popoverPlacement: 'on the right',
         arrow: toRight.arrow,

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -177,8 +177,7 @@ function updatePopover({
     popover.style.top = 'var(--paranovel-popover-inset-size)';
     popover.style.boxSizing = 'border-box';
     popover.style.display = 'block';
-    // popover.style.visibility = 'hidden';
-    popover.style.visibility = 'visible';
+    popover.style.visibility = 'hidden';
 
     // 'auto' may produce a floating-point number, while clientWidth and
     // clientHeight produce a floored version of that number
@@ -674,16 +673,19 @@ function calculatePopoverLayoutForPlacement(params) {
           ? popoverPreferredSize.width >= width
           : popoverPreferredSize.height >= height
       ) {
-        return provisionalLayout;
+        return { type: 'unchanged', layout: provisionalLayout };
       }
 
-      return calculatePopoverLayoutForPlacement({
-        ...params,
-        popoverPreferredSize,
-      });
+      return {
+        type: 'updated',
+        layout: calculatePopoverLayoutForPlacement({
+          ...params,
+          popoverPreferredSize,
+        }),
+      };
     }
 
-    return provisionalLayout;
+    return { type: 'unchanged', layout: provisionalLayout };
   };
 
   switch (popoverPlacement) {
@@ -709,7 +711,7 @@ function calculatePopoverLayoutForPlacement(params) {
       // ┃ f ⏷                        ┃   ┃                        ⏷ f ┃
       // ┃ g n                        ┃   ┃                        n g ┃
       // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-      let above = {
+      const above = {
         popoverPlacement: 'above',
         // FIXME: would be nice to ensure the arrow stays within
         //        popoverInsetSize, as otherwise, when the arrow is at the
@@ -731,7 +733,10 @@ function calculatePopoverLayoutForPlacement(params) {
         },
       };
 
-      above = handleInsufficientInlineSpace(above);
+      const result = handleInsufficientInlineSpace(above);
+      if (result.type === 'updated') {
+        return result.layout;
+      }
 
       const aboveAdjusted = {
         popoverPlacement: 'above',
@@ -771,7 +776,7 @@ function calculatePopoverLayoutForPlacement(params) {
       // ┃ g o                        ┃   ┃                        o g ┃
       // ┃ h p                        ┃   ┃                        p h ┃
       // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-      let below = {
+      const below = {
         popoverPlacement: 'below',
         arrow: {
           x: clientRect.left + clientRect.width / 2 - arrowSize.breadth / 2,
@@ -793,7 +798,10 @@ function calculatePopoverLayoutForPlacement(params) {
         },
       };
 
-      below = handleInsufficientInlineSpace(below);
+      const result = handleInsufficientInlineSpace(below);
+      if (result.type === 'updated') {
+        return result.layout;
+      }
 
       const belowAdjusted = {
         popoverPlacement: 'below',
@@ -833,7 +841,7 @@ function calculatePopoverLayoutForPlacement(params) {
       // ┃ g g g g g g g g g g g g    ┃   ┃                            ┃
       // ┃ h h h h h h h h h h h h    ┃   ┃                            ┃
       // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-      let toLeft = {
+      const toLeft = {
         popoverPlacement: 'on the left',
         arrow: {
           x: clientRect.left - arrowSize.length,
@@ -852,7 +860,10 @@ function calculatePopoverLayoutForPlacement(params) {
         },
       };
 
-      toLeft = handleInsufficientInlineSpace(toLeft);
+      const result = handleInsufficientInlineSpace(toLeft);
+      if (result.type === 'updated') {
+        return result.layout;
+      }
 
       const toLeftAdjusted = {
         popoverPlacement: 'on the left',
@@ -897,7 +908,7 @@ function calculatePopoverLayoutForPlacement(params) {
         width: arrowSize.length,
         height: arrowSize.breadth,
       };
-      let toRight = {
+      const toRight = {
         popoverPlacement: 'on the right',
         arrow: toRightArrow,
         popover: {
@@ -921,7 +932,10 @@ function calculatePopoverLayoutForPlacement(params) {
         },
       };
 
-      toRight = handleInsufficientInlineSpace(toRight);
+      const result = handleInsufficientInlineSpace(toRight);
+      if (result.type === 'updated') {
+        return result.layout;
+      }
 
       const toRightAdjusted = {
         popoverPlacement: 'on the right',


### PR DESCRIPTION
I realised that the preferred block size is only meaningful so long as the preferred inline size is satisfied. If you can't satisfy the preferred inline size due to needing to lay out in a certain orientation that lacks the available space to do so, then you need to perform another layout pass to get the "preferred size for that given orientation".