### PR TITLE
Give up on rendering popover in WebView due to WebKit bugs; migrate to native popover.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "debug:ios": "DEBUG=expo:* expo run:ios",
     "test": "jest --watchAll",
     "lint": "expo lint",
+    "provision": "node ./scripts/provision-ebook.ts",
     "postinstall": "patch-package"
   },
   "jest": {

--- a/scripts/provision-ebook.ts
+++ b/scripts/provision-ebook.ts
@@ -70,7 +70,7 @@ async function main() {
   for (const [_simulator, { deviceName, storagePath }] of simulators) {
     console.log(`Syncing ${deviceName}...`);
 
-    const stdout = await syncEbooks({
+    await syncEbooks({
       source: '/Users/jamie/Library/Mobile Documents/com~apple~CloudDocs/epubs',
       dest: path.resolve(storagePath, 'epubs'),
       extraFlags: [
@@ -81,7 +81,6 @@ async function main() {
         '--exclude=AZW3 to EPUB.app',
       ],
     });
-    console.log(stdout);
   }
 }
 
@@ -129,7 +128,7 @@ function syncEbooks({
   dest: string;
   extraFlags?: Array<string>;
 }) {
-  return new Promise<string>((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     const command = [
       'rsync',
       [
@@ -182,7 +181,7 @@ function syncEbooks({
         return;
       }
 
-      resolve(stdout);
+      resolve();
     });
   });
 }

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -14,6 +14,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   useColorScheme,
+  View,
 } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 
@@ -27,7 +28,7 @@ import {
   parseNCX,
   parseOPF,
 } from '@/utils/epub-parsing';
-import { lookUpTerm } from '@/utils/look-up-term';
+import { LookupResult, lookUpTerm } from '@/utils/look-up-term';
 import type { RootStackParamList } from './navigation.types';
 import injectedCss from './source-assets/injected-css.wvcss';
 import mainScript from './source-assets/injected-javascript.wvjs';
@@ -289,6 +290,21 @@ export default function BookScreen({
     });
   }, [navigation, params, spine, toc]);
 
+  const [nativePopup, setNativePopup] = useState<NativePopupState>({
+    visible: false,
+    anchorRect: {
+      top: 0,
+      right: 0,
+      left: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+    },
+    results: [],
+  });
+
   const onMessageCallback = useCallback((event: WebViewMessageEvent) => {
     onMessage({
       event,
@@ -299,6 +315,7 @@ export default function BookScreen({
       webViewUriRef,
       setWebViewUri,
       pageDetailsQueryDataRef,
+      setNativePopup,
     });
   }, []);
 
@@ -495,8 +512,50 @@ export default function BookScreen({
           return false;
         }}
       />
+      <NativePopover state={nativePopup} />
     </SafeAreaView>
   );
+}
+
+function NativePopover({ state }: { state: NativePopupState }) {
+  const {
+    visible,
+    anchorRect: { top, left, width, height },
+    results,
+  } = state;
+
+  console.log('AHOY', state.anchorRect);
+
+  // Currently we're reflecting the anchorRect.
+  // TODO: see layOutPopover() in `src/source-assets/injected-javascript.wvjs`
+  //       and run the multi-try `tryOrientation()` .
+  return (
+    <View
+      style={{
+        backgroundColor: 'cyan',
+        width,
+        height,
+        top,
+        left,
+        position: 'absolute',
+        display: visible ? 'flex' : 'none',
+      }}></View>
+  );
+}
+
+interface NativePopupState {
+  visible: boolean;
+  anchorRect: {
+    top: number;
+    right: number;
+    left: number;
+    bottom: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  results: Array<LookupResult>;
 }
 
 function stringDiff(a: string, b: string) {
@@ -552,6 +611,7 @@ function onMessage({
   paramsRef,
   webViewUriRef,
   setWebViewUri,
+  setNativePopup,
   pageDetailsQueryDataRef,
 }: {
   event: WebViewMessageEvent;
@@ -567,6 +627,7 @@ function onMessage({
   paramsRef: React.MutableRefObject<Readonly<BookScreenProps>>;
   webViewUriRef: React.MutableRefObject<string>;
   setWebViewUri: React.Dispatch<React.SetStateAction<string>>;
+  setNativePopup: React.Dispatch<React.SetStateAction<NativePopupState>>;
   pageDetailsQueryDataRef: React.MutableRefObject<
     | {
         pageType: 'toc';
@@ -591,6 +652,13 @@ function onMessage({
     id: number;
     term: string;
   }
+  interface PresentNativePayloadPayload {
+    type: 'present-native-popover';
+    id: number;
+    anchorRect: DOMRect;
+    positionTryOrder: ['bottom', 'top'] | ['right', 'left'] | ['left', 'right'];
+    results: Array<LookupResult>;
+  }
   interface TokenizePayload {
     type: 'tokenize';
     id: number;
@@ -611,6 +679,7 @@ function onMessage({
   type Payload =
     | LogPayload
     | LookUpPayload
+    | PresentNativePayloadPayload
     | TokenizePayload
     | NavigationRequestPayload
     | ProgressPayload;
@@ -682,6 +751,16 @@ function onMessage({
             }"`,
           );
         });
+      return;
+    }
+    case 'present-native-popover': {
+      const {
+        id: _transactionId,
+        positionTryOrder,
+        anchorRect,
+        results,
+      } = parsed;
+      setNativePopup({ visible: true, anchorRect, results });
       return;
     }
     case 'navigation-request': {

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -21,6 +22,7 @@ import {
   Text,
   Pressable,
   ScrollView,
+  ReadOnlyElement,
 } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 
@@ -518,24 +520,148 @@ export default function BookScreen({
           return false;
         }}
       />
-      <NativePopover state={nativePopup} />
+      <NativePopover state={nativePopup} writingMode="vertical-rl" />
     </SafeAreaView>
   );
 }
 
-function NativePopover({ state }: { state: NativePopupState }) {
+function NativePopover({
+  state,
+  writingMode = 'horizontal-tb',
+}: {
+  state: NativePopupState;
+  writingMode?: string;
+}) {
   const { visible, anchorRect, results } = state;
   const { top, left, width, height } = anchorRect;
-
   const [withShowMoreButton, _setWithShowMoreButton] = useState(false);
 
-  console.log('AHOY', state.anchorRect);
+  const positionTryOrder = getBestPositionTryOrder(writingMode);
 
-  // Currently we're reflecting the anchorRect.
-  // TODO: see layOutPopover() in `src/source-assets/injected-javascript.wvjs`
-  //       and run the multi-try `tryOrientation()` .
+  console.log('AHOY', results);
 
-  const stageStyles = tryOrientation({ anchorRect, orientation: 'left' });
+  const stageRef = useRef<View | null>(null);
+  const scrollViewRef = useRef<ScrollView | null>(null);
+  useEffect(() => {
+    const scrollView = scrollViewRef.current;
+    const stage = stageRef.current;
+    const parent = stage?.parentElement;
+    if (!stage || !scrollView || !parent) {
+      return;
+    }
+
+    const solutions = new Array<{
+      orientation: Orientation;
+      blockOverflow: number;
+      clientInlineSize: number;
+    }>();
+
+    let lastTried: Orientation = positionTryOrder[0];
+
+    // FIXME: In the no-results case, 'left' will win over 'right' in
+    //        vertical-rl texts no matter how cramped, just because the
+    //        clientInlineSize (the clientHeight) is equal between the two.
+    //
+    //        This might be resolvable (for the wrong reasons) by just
+    //        implementing the "no results" text and, if possible, a minimum
+    //        width.
+    for (const orientation of positionTryOrder) {
+      lastTried = orientation;
+
+      const style = tryOrientation({ anchorRect, orientation, parent });
+      stage.setNativeProps({ style });
+      const {
+        blockOverflow,
+        inlineOverflow,
+        clientBlockSize,
+        clientInlineSize,
+      } = getOverflow({ scrollView, orientation });
+
+      const typedStyle = style as {
+        top: number;
+        right: number;
+        bottom: number;
+        left: number;
+      };
+
+      // On the Web, we compared the bounding client rect to the window's
+      // innerWidth/innerHeight. In React Native, the bounding client rect seems
+      // to stay diligently inside the parent no matter what impossible
+      // constraint you asked for, so the non-computed style gets closer to my
+      // intention of checking whether we asked for a stage that begins outside
+      // of the viewport.
+      let isOverflowingViewport = false;
+      if (
+        typedStyle.left > parent.clientWidth ||
+        typedStyle.right > parent.clientWidth ||
+        typedStyle.top < 0 ||
+        typedStyle.bottom < 0 ||
+        typedStyle.top > parent.clientHeight ||
+        typedStyle.bottom > parent.clientHeight
+      ) {
+        isOverflowingViewport = true;
+      }
+
+      if (isOverflowingViewport) {
+        console.log(
+          `Discarding orientation "${orientation}" as it's overflowing the viewport.`,
+        );
+        continue;
+      }
+
+      if (inlineOverflow) {
+        console.log(
+          `Discarding orientation "${orientation}" as it's overflowing in the inline orientation.`,
+        );
+        continue;
+      }
+
+      solutions.push({ orientation, blockOverflow, clientInlineSize });
+    }
+
+    const sortedSolutions = solutions.sort((a, b) => {
+      // Sort in descending order of inline size.
+      const clientInlineSize = b.clientInlineSize - a.clientInlineSize;
+
+      // If there's no tie, use that alone as the sorting factor.
+      if (clientInlineSize) {
+        return clientInlineSize;
+      }
+
+      // Otherwise, sort in ascending order of block overflow.
+      //
+      // (Given that we reserve the same amount of block space for both
+      // orientations, though, this won't actually make any difference unless we
+      // change the layout algorithm in future.)
+      return a.blockOverflow - b.blockOverflow;
+    });
+    const bestSolution = sortedSolutions.at(0)?.orientation;
+
+    if (!bestSolution) {
+      return;
+    }
+
+    if (bestSolution === lastTried) {
+      console.log(
+        `Given solutions ${JSON.stringify(
+          sortedSolutions,
+        )}, picking ${bestSolution} (last tried)`,
+      );
+    } else {
+      console.log(
+        `Given solutions ${JSON.stringify(
+          sortedSolutions,
+        )}, picking ${bestSolution} (redoing layout)`,
+      );
+
+      const style = tryOrientation({
+        anchorRect,
+        orientation: bestSolution,
+        parent,
+      });
+      stage.setNativeProps({ style });
+    }
+  }, [anchorRect, results]);
 
   const fontScale = 1;
   const paranovelPopoverDefinitionFontSize = 14 / fontScale;
@@ -556,16 +682,18 @@ function NativePopover({ state }: { state: NativePopupState }) {
         }}></View>
       <View
         // #paranovel-popover-stage
+        ref={stageRef}
         style={{
           position: 'absolute',
           backgroundColor: 'rgba(255,255,0,0.5)',
           inset: 0,
           padding: 16,
           alignItems: 'center',
-          ...stageStyles,
+          // ...stageStyles,
           display: visible ? 'flex' : 'none',
         }}>
         <ScrollView
+          ref={scrollViewRef}
           // #paranovel-popover-content
           style={{
             backgroundColor: 'black',
@@ -700,135 +828,194 @@ function NativePopover({ state }: { state: NativePopupState }) {
   );
 }
 
+/**
+ * For now, the popover is always formatted as horizontal-lr, even if the
+ * ebook is vertical-rl. This is, in chief, because I'm starting with a
+ * Japanese-English dictionary, and vertical-rl does not suit English text.
+ */
+const popoverWritingDirectionMatchesBodyText: boolean = false;
+
+function getBestPositionTryOrder(
+  writingMode: string,
+): ['bottom', 'top'] | ['right', 'left'] | ['left', 'right'] {
+  /**
+   * A tactic to emulate the following CSS:
+   *
+   * ```css
+   * position-area: block-end span-all;
+   * position-try: most-block-size flip-block;
+   * ```
+   */
+  switch (writingMode) {
+    case 'lr':
+    case 'lr-tb':
+    case 'rl':
+    case 'horizontal-tb': {
+      return ['bottom', 'top'];
+    }
+    case 'tb-lr':
+    case 'tb-rl':
+    case 'sideways-rl':
+    case 'vertical-rl':
+    case 'sideways-lr':
+    case 'vertical-lr': {
+      return writingMode.endsWith('rl') ? ['left', 'right'] : ['right', 'left'];
+    }
+    default: {
+      throw new Error(`Unexpected writing mode, ${writingMode}`);
+    }
+  }
+}
+
 function tryOrientation({
   anchorRect,
   orientation,
+  parent,
 }: {
   anchorRect: Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'>;
   orientation: Orientation;
+  parent: ReadOnlyElement;
 }): StyleProp<ViewStyle> {
   // `anchorRect` is measured entirely from the top-left (i.e. `bottom` is the
   // number of pixels down from the top; it's equivalent to `top` + `height`).
   const { top, left, bottom, right } = anchorRect;
-
-  // popoverStage.style.removeProperty('top');
-  // popoverStage.style.removeProperty('right');
-  // popoverStage.style.removeProperty('bottom');
-  // popoverStage.style.removeProperty('left');
-
-  // /**
-  //  * For now, the popover is always formatted as horizontal-lr, even if the
-  //  * ebook is vertical-rl. This is, in chief, because I'm starting with a
-  //  * Japanese-English dictionary, and vertical-rl does not suit English text.
-  //  */
-  // const popoverWritingDirectionMatchesBodyText = false;
-
-  // let blockOverflow = 0;
-  // let inlineOverflow = 0;
-  // let clientBlockSize = 0;
-  // let clientInlineSize = 0;
-
-  // const windowInnerHeight =
 
   switch (orientation) {
     case 'top': {
       return {
         flexDirection: 'column',
         justifyContent: 'flex-end',
-        bottom: Dimensions.get('window').height - top,
+        top: 0,
+        right: 0,
+        bottom: parent.clientHeight - top,
+        left: 0,
       };
-
-      // blockOverflow = popoverContent.scrollHeight - popoverContent.clientHeight;
-      // inlineOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
-      // clientBlockSize = popoverContent.clientHeight;
-      // clientInlineSize = popoverContent.clientWidth;
-      // break;
     }
     case 'right': {
       return {
         flexDirection: 'row',
         justifyContent: 'flex-start',
+        top: 0,
+        right: 0,
+        bottom: 0,
         left: right,
       };
-      // if (popoverWritingDirectionMatchesBodyText) {
-      //   blockOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
-      //   inlineOverflow =
-      //     popoverContent.scrollHeight - popoverContent.clientHeight;
-      //   clientBlockSize = popoverContent.clientWidth;
-      //   clientInlineSize = popoverContent.clientHeight;
-      // } else {
-      //   blockOverflow =
-      //     popoverContent.scrollHeight - popoverContent.clientHeight;
-      //   inlineOverflow =
-      //     popoverContent.scrollWidth - popoverContent.clientWidth;
-      //   clientBlockSize = popoverContent.clientHeight;
-      //   clientInlineSize = popoverContent.clientWidth;
-      // }
-      // break;
     }
     case 'bottom': {
       return {
         flexDirection: 'column',
         justifyContent: 'flex-start',
+        top: 0,
+        right: 0,
+        bottom: 0,
         left: bottom,
       };
-
-      // blockOverflow = popoverContent.scrollHeight - popoverContent.clientHeight;
-      // inlineOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
-      // clientBlockSize = popoverContent.clientHeight;
-      // clientInlineSize = popoverContent.clientWidth;
-      // break;
     }
     case 'left': {
       return {
         flexDirection: 'row',
         justifyContent: 'flex-end',
-        right: Dimensions.get('window').width - left,
+        top: 0,
+        right: parent.clientWidth - left,
+        bottom: 0,
+        left: 0,
       };
+    }
+  }
+}
 
-      // popoverStage.style.flexDirection = 'row';
-      // popoverStage.style.justifyContent = 'flex-end';
-      // popoverStage.style.right = `${window.innerWidth - left}px`;
-      // if (popoverWritingDirectionMatchesBodyText) {
-      //   blockOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
-      //   inlineOverflow =
-      //     popoverContent.scrollHeight - popoverContent.clientHeight;
-      //   clientBlockSize = popoverContent.clientWidth;
-      //   clientInlineSize = popoverContent.clientHeight;
-      // } else {
-      //   blockOverflow =
-      //     popoverContent.scrollHeight - popoverContent.clientHeight;
-      //   inlineOverflow =
-      //     popoverContent.scrollWidth - popoverContent.clientWidth;
-      //   clientBlockSize = popoverContent.clientHeight;
-      //   clientInlineSize = popoverContent.clientWidth;
-      // }
-      // break;
+function getOverflow({
+  scrollView,
+  orientation,
+}: {
+  scrollView: ScrollView;
+  orientation: Orientation;
+}) {
+  /**
+   * For now, the popover is always formatted as horizontal-lr, even if the
+   * ebook is vertical-rl. This is, in chief, because I'm starting with a
+   * Japanese-English dictionary, and vertical-rl does not suit English text.
+   */
+  const popoverWritingDirectionMatchesBodyText = false;
+
+  let blockOverflow = 0;
+  let inlineOverflow = 0;
+  let clientBlockSize = 0;
+  let clientInlineSize = 0;
+
+  const nativeScrollRef = scrollView.getNativeScrollRef();
+  if (!nativeScrollRef) {
+    return {
+      blockOverflow,
+      inlineOverflow,
+      clientBlockSize,
+      clientInlineSize,
+    };
+  }
+
+  switch (orientation) {
+    case 'top': {
+      blockOverflow =
+        nativeScrollRef.scrollHeight - nativeScrollRef.clientHeight;
+      inlineOverflow =
+        nativeScrollRef.scrollWidth - nativeScrollRef.clientWidth;
+      clientBlockSize = nativeScrollRef.clientHeight;
+      clientInlineSize = nativeScrollRef.clientWidth;
+      break;
+    }
+    case 'right': {
+      if (popoverWritingDirectionMatchesBodyText) {
+        blockOverflow =
+          nativeScrollRef.scrollWidth - nativeScrollRef.clientWidth;
+        inlineOverflow =
+          nativeScrollRef.scrollHeight - nativeScrollRef.clientHeight;
+        clientBlockSize = nativeScrollRef.clientWidth;
+        clientInlineSize = nativeScrollRef.clientHeight;
+      } else {
+        blockOverflow =
+          nativeScrollRef.scrollHeight - nativeScrollRef.clientHeight;
+        inlineOverflow =
+          nativeScrollRef.scrollWidth - nativeScrollRef.clientWidth;
+        clientBlockSize = nativeScrollRef.clientHeight;
+        clientInlineSize = nativeScrollRef.clientWidth;
+      }
+      break;
+    }
+    case 'bottom': {
+      blockOverflow =
+        nativeScrollRef.scrollHeight - nativeScrollRef.clientHeight;
+      inlineOverflow =
+        nativeScrollRef.scrollWidth - nativeScrollRef.clientWidth;
+      clientBlockSize = nativeScrollRef.clientHeight;
+      clientInlineSize = nativeScrollRef.clientWidth;
+      break;
+    }
+    case 'left': {
+      if (popoverWritingDirectionMatchesBodyText) {
+        blockOverflow =
+          nativeScrollRef.scrollWidth - nativeScrollRef.clientWidth;
+        inlineOverflow =
+          nativeScrollRef.scrollHeight - nativeScrollRef.clientHeight;
+        clientBlockSize = nativeScrollRef.clientWidth;
+        clientInlineSize = nativeScrollRef.clientHeight;
+      } else {
+        blockOverflow =
+          nativeScrollRef.scrollHeight - nativeScrollRef.clientHeight;
+        inlineOverflow =
+          nativeScrollRef.scrollWidth - nativeScrollRef.clientWidth;
+        clientBlockSize = nativeScrollRef.clientHeight;
+        clientInlineSize = nativeScrollRef.clientWidth;
+      }
+      break;
     }
   }
 
-  // const stageRect = popoverContent.getBoundingClientRect();
-
-  // // Although the anchor may be fully onscreen, some orientations around it may
-  // // cause the popover to fall offscreen.
-  // let isOverflowingViewport = false;
-  // if (
-  //   stageRect.top < 0 ||
-  //   stageRect.left < 0 ||
-  //   stageRect.bottom > window.innerHeight ||
-  //   stageRect.right > window.innerWidth
-  // ) {
-  //   isOverflowingViewport = true;
-  // }
-
-  // return {
-  //   blockOverflow,
-  //   inlineOverflow,
-  //   clientBlockSize,
-  //   clientInlineSize,
-  //   isOverflowingViewport,
-  //   stageRect,
-  // };
+  return {
+    blockOverflow,
+    inlineOverflow,
+    clientBlockSize,
+    clientInlineSize,
+  };
 }
 
 type Orientation = 'top' | 'right' | 'bottom' | 'left';

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -552,134 +552,128 @@ function NativePopover({
   const { visible, anchorRect, results, positionTryOrder } = state;
   const { top, left, width, height } = anchorRect;
   const [withShowMoreButton, _setWithShowMoreButton] = useState(false);
+  const debugStyles: boolean = false;
 
   const stageRef = useRef<View | null>(null);
   const scrollViewRef = useRef<ScrollView | null>(null);
   useEffect(() => {
-    const scrollView = scrollViewRef.current;
-    const stage = stageRef.current;
-    const parent = stage?.parentElement;
-    if (!stage || !scrollView || !parent) {
-      return;
-    }
-
-    const solutions = new Array<{
-      orientation: Orientation;
-      blockOverflow: number;
-      clientInlineSize: number;
-    }>();
-
-    let lastTried: Orientation = positionTryOrder[0];
-
-    // FIXME: In the no-results case, 'left' will win over 'right' in
-    //        vertical-rl texts no matter how cramped, just because the
-    //        clientInlineSize (the clientHeight) is equal between the two.
-    //
-    //        This might be resolvable (for the wrong reasons) by just
-    //        implementing the "no results" text and, if possible, a minimum
-    //        width.
-    for (const orientation of positionTryOrder) {
-      lastTried = orientation;
-
-      const style = tryOrientation({ anchorRect, orientation, parent });
-      stage.setNativeProps({ style });
-      const {
-        blockOverflow,
-        inlineOverflow,
-        clientBlockSize,
-        clientInlineSize,
-      } = getOverflow({ scrollView, orientation });
-
-      const typedStyle = style as {
-        top: number;
-        right: number;
-        bottom: number;
-        left: number;
-      };
-
-      // On the Web, we compared the bounding client rect to the window's
-      // innerWidth/innerHeight. In React Native, the bounding client rect seems
-      // to stay diligently inside the parent no matter what impossible
-      // constraint you asked for, so the non-computed style gets closer to my
-      // intention of checking whether we asked for a stage that begins outside
-      // of the viewport.
-      let isOverflowingViewport = false;
-      if (
-        typedStyle.left > parent.clientWidth ||
-        typedStyle.right > parent.clientWidth ||
-        typedStyle.top < 0 ||
-        typedStyle.bottom < 0 ||
-        typedStyle.top > parent.clientHeight ||
-        typedStyle.bottom > parent.clientHeight
-      ) {
-        isOverflowingViewport = true;
+    const asyncEffect = async () => {
+      const scrollView = scrollViewRef.current;
+      const stage = stageRef.current;
+      const parent = stage?.parentElement;
+      if (!stage || !scrollView || !parent) {
+        return;
       }
 
-      if (isOverflowingViewport) {
-        console.log(
-          `Discarding orientation "${orientation}" as it's overflowing the viewport.`,
-        );
-        continue;
+      const solutions = new Array<{
+        orientation: Orientation;
+        blockOverflow: number;
+        clientInlineSize: number;
+        clientBlockSize: number;
+      }>();
+
+      let lastTried: Orientation = positionTryOrder[0];
+      for (const orientation of positionTryOrder) {
+        lastTried = orientation;
+
+        const style = tryOrientation({ anchorRect, orientation, parent });
+        stage.setNativeProps({
+          style: { ...style, opacity: debugStyles ? 1 : 0 },
+        });
+        // We need to wait an animation frame for the clientWidth, clientHeight,
+        // etc. to be recalculated.
+        await new Promise(resolve => requestAnimationFrame(resolve));
+        const {
+          blockOverflow,
+          inlineOverflow,
+          clientBlockSize,
+          clientInlineSize,
+        } = getOverflow({ scrollView, orientation });
+
+        const boundingClientRect = stage.getBoundingClientRect();
+        console.log(`Orientation ${orientation} got style`, {
+          clientInlineSize,
+          clientBlockSize,
+          boundingClientRect,
+        });
+
+        // Handles the majority of cases where the popover should be
+        // disqualified for being too cramped. For now, assumes the popover is
+        // horizontal-tb.
+        if (boundingClientRect.width < clientInlineSize) {
+          console.log(
+            `Discarding orientation "${orientation}" as it's unable to satisfy the minimum width constraint.`,
+          );
+          continue;
+        }
+
+        // Presumably due to rounding errors, it's normal for the inlineOverflow
+        // to be exactly 1 (despite not apparently overflowing).
+        if (inlineOverflow > 1) {
+          console.log(
+            `Discarding orientation "${orientation}" as it's overflowing in the inline orientation by ${inlineOverflow}.`,
+          );
+          continue;
+        }
+
+        solutions.push({
+          orientation,
+          blockOverflow,
+          clientInlineSize,
+          clientBlockSize,
+        });
       }
 
-      if (inlineOverflow) {
-        console.log(
-          `Discarding orientation "${orientation}" as it's overflowing in the inline orientation.`,
-        );
-        continue;
-      }
+      const sortedSolutions = solutions.sort((a, b) => {
+        // Sort in descending order of inline size (i.e. 'width', so long as our
+        // popover continues to be horizontal-tb).
+        const clientInlineSize = b.clientInlineSize - a.clientInlineSize;
 
-      solutions.push({ orientation, blockOverflow, clientInlineSize });
-    }
+        // If there's no tie, use that alone as the sorting factor.
+        if (clientInlineSize) {
+          return clientInlineSize;
+        }
 
-    const sortedSolutions = solutions.sort((a, b) => {
-      // Sort in descending order of inline size.
-      const clientInlineSize = b.clientInlineSize - a.clientInlineSize;
-
-      // If there's no tie, use that alone as the sorting factor.
-      if (clientInlineSize) {
-        return clientInlineSize;
-      }
-
-      // Otherwise, sort in ascending order of block overflow.
-      //
-      // (Given that we reserve the same amount of block space for both
-      // orientations, though, this won't actually make any difference unless we
-      // change the layout algorithm in future.)
-      return a.blockOverflow - b.blockOverflow;
-    });
-    const bestSolution = sortedSolutions.at(0)?.orientation;
-
-    if (!bestSolution) {
-      return;
-    }
-
-    if (bestSolution === lastTried) {
-      console.log(
-        `Given solutions ${JSON.stringify(
-          sortedSolutions,
-        )}, picking ${bestSolution} (last tried)`,
-      );
-    } else {
-      console.log(
-        `Given solutions ${JSON.stringify(
-          sortedSolutions,
-        )}, picking ${bestSolution} (redoing layout)`,
-      );
-
-      const style = tryOrientation({
-        anchorRect,
-        orientation: bestSolution,
-        parent,
+        // Otherwise, sort in ascending order of block overflow.
+        //
+        // (Given that we reserve the same amount of block space for both
+        // orientations, though, this won't actually make any difference unless we
+        // change the layout algorithm in future.)
+        return a.blockOverflow - b.blockOverflow;
       });
-      stage.setNativeProps({ style });
-    }
-  }, [anchorRect, results]);
+      const bestSolution = sortedSolutions.at(0)?.orientation;
+
+      if (!bestSolution) {
+        return;
+      }
+
+      if (bestSolution === lastTried) {
+        console.log(
+          `Given solutions ${JSON.stringify(
+            sortedSolutions,
+          )}, picking ${bestSolution} (last tried)`,
+        );
+        stage.setNativeProps({ style: { opacity: 1 } });
+      } else {
+        console.log(
+          `Given solutions ${JSON.stringify(
+            sortedSolutions,
+          )}, picking ${bestSolution} (redoing layout)`,
+        );
+
+        const style = tryOrientation({
+          anchorRect,
+          orientation: bestSolution,
+          parent,
+        });
+        stage.setNativeProps({ style: { ...style, opacity: 1 } });
+      }
+    };
+    asyncEffect();
+  }, [anchorRect, results, debugStyles]);
 
   const fontScale = 1;
   const paranovelPopoverDefinitionFontSize = 14 / fontScale;
-
-  const debugStyles: boolean = false;
   const touchState = useRef<{ type: 'idle' } | { type: 'start' }>({
     type: 'idle',
   });
@@ -780,6 +774,7 @@ function NativePopover({
               // maxWidth: '100%',
               // height: 'fit-content',
               // maxHeight: '100%',
+              minWidth: 100,
             }}>
             {results.map(({ forms, senses }, i) => {
               const readings = forms

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -532,10 +532,6 @@ function NativePopover({ state }: { state: NativePopupState }) {
   const { top, left, width, height } = anchorRect;
   const [withShowMoreButton, _setWithShowMoreButton] = useState(false);
 
-  // const positionTryOrder = getBestPositionTryOrder(writingMode);
-
-  console.log('AHOY', results);
-
   const stageRef = useRef<View | null>(null);
   const scrollViewRef = useRef<ScrollView | null>(null);
   useEffect(() => {
@@ -822,45 +818,6 @@ function NativePopover({ state }: { state: NativePopupState }) {
       </View>
     </>
   );
-}
-
-/**
- * For now, the popover is always formatted as horizontal-lr, even if the
- * ebook is vertical-rl. This is, in chief, because I'm starting with a
- * Japanese-English dictionary, and vertical-rl does not suit English text.
- */
-const popoverWritingDirectionMatchesBodyText: boolean = false;
-
-function getBestPositionTryOrder(
-  writingMode: string,
-): ['bottom', 'top'] | ['right', 'left'] | ['left', 'right'] {
-  /**
-   * A tactic to emulate the following CSS:
-   *
-   * ```css
-   * position-area: block-end span-all;
-   * position-try: most-block-size flip-block;
-   * ```
-   */
-  switch (writingMode) {
-    case 'lr':
-    case 'lr-tb':
-    case 'rl':
-    case 'horizontal-tb': {
-      return ['bottom', 'top'];
-    }
-    case 'tb-lr':
-    case 'tb-rl':
-    case 'sideways-rl':
-    case 'vertical-rl':
-    case 'sideways-lr':
-    case 'vertical-lr': {
-      return writingMode.endsWith('rl') ? ['left', 'right'] : ['right', 'left'];
-    }
-    default: {
-      throw new Error(`Unexpected writing mode, ${writingMode}`);
-    }
-  }
 }
 
 function tryOrientation({

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -698,207 +698,212 @@ function NativePopover({
           left,
           display: debugStyles && visible ? 'flex' : 'none',
         }}></View>
-      <View
-        // #paranovel-popover-stage
-        ref={stageRef}
-        style={{
-          position: 'absolute',
-          backgroundColor: debugStyles ? 'rgba(255,255,0,0.5)' : undefined,
-          inset: 0,
-          padding: 16,
-          alignItems: 'center',
-          // ...stageStyles,
-          display: visible ? 'flex' : 'none',
-        }}
-        onTouchStart={({ nativeEvent: { pageX, pageY } }) => {
-          const rect = scrollViewRef.current
-            ?.getNativeScrollRef()
-            ?.getBoundingClientRect();
-          if (!rect) {
-            return;
-          }
-
-          const { top, right, bottom, left } = rect;
-          if (
-            pageX >= left &&
-            pageX <= right &&
-            pageY >= top &&
-            pageY <= bottom
-          ) {
-            // The touch upon the stage fell inside the ScrollView.
-            return;
-          }
-
-          touchState.current = { type: 'start' };
-        }}
-        onTouchCancel={() => {
-          touchState.current = { type: 'idle' };
-        }}
-        onTouchEnd={({ nativeEvent: { pageX, pageY } }) => {
-          const initialState = touchState.current;
-          touchState.current = { type: 'idle' };
-
-          if (initialState.type !== 'start') {
-            return;
-          }
-
-          const rect = scrollViewRef.current
-            ?.getNativeScrollRef()
-            ?.getBoundingClientRect();
-          if (!rect) {
-            return;
-          }
-
-          const { top, right, bottom, left } = rect;
-          if (
-            pageX >= left &&
-            pageX <= right &&
-            pageY >= top &&
-            pageY <= bottom
-          ) {
-            // The touch upon the stage fell inside the ScrollView.
-            return;
-          }
-
-          // FIXME: The scroll offset from previous render will persist.
-          // Both scrollTo() and setNativeProps(), are getting ignored.
-          // We may need to remove it from the view tree altogether (rather than
-          // setting `display: none`) just to reset the state.
-
-          closePopover();
-        }}>
-        <ScrollView
-          ref={scrollViewRef}
-          // #paranovel-popover-content
+      {/*
+        When toggling visibility, we make sure to unmount, as it resets the
+        scroll offset for free (I did try scrollTo() and setNativeProps(), but
+        they don't seem to have any effect for some reason).
+      */}
+      {visible && (
+        <View
+          // #paranovel-popover-stage
+          ref={stageRef}
           style={{
-            backgroundColor: 'black',
-            padding: 8,
-            boxSizing: 'border-box',
-            // It doesn't seem to be respecting this
-            // overflow: 'scroll',
+            position: 'absolute',
+            backgroundColor: debugStyles ? 'rgba(255,255,0,0.5)' : undefined,
+            inset: 0,
+            padding: 16,
+            alignItems: 'center',
+            // ...stageStyles,
+          }}
+          onTouchStart={({ nativeEvent: { pageX, pageY } }) => {
+            const rect = scrollViewRef.current
+              ?.getNativeScrollRef()
+              ?.getBoundingClientRect();
+            if (!rect) {
+              return;
+            }
 
-            // maxWidth: '100%',
-            // height: 'fit-content',
-            // maxHeight: '100%',
+            const { top, right, bottom, left } = rect;
+            if (
+              pageX >= left &&
+              pageX <= right &&
+              pageY >= top &&
+              pageY <= bottom
+            ) {
+              // The touch upon the stage fell inside the ScrollView.
+              return;
+            }
+
+            touchState.current = { type: 'start' };
+          }}
+          onTouchCancel={() => {
+            touchState.current = { type: 'idle' };
+          }}
+          onTouchEnd={({ nativeEvent: { pageX, pageY } }) => {
+            const initialState = touchState.current;
+            touchState.current = { type: 'idle' };
+
+            if (initialState.type !== 'start') {
+              return;
+            }
+
+            const rect = scrollViewRef.current
+              ?.getNativeScrollRef()
+              ?.getBoundingClientRect();
+            if (!rect) {
+              return;
+            }
+
+            const { top, right, bottom, left } = rect;
+            if (
+              pageX >= left &&
+              pageX <= right &&
+              pageY >= top &&
+              pageY <= bottom
+            ) {
+              // The touch upon the stage fell inside the ScrollView.
+              return;
+            }
+
+            closePopover();
           }}>
-          {results.map(({ forms, senses }, i) => {
-            const readings = forms
-              .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))
-              .filter(({ kana }) => kana);
-
-            return (
-              <View
-                key={i}
-                // .paranovel-result-container
-                style={{
-                  gap: 8,
-                  alignItems: 'stretch',
-                  maxWidth: '100%',
-
-                  // To be inherited:
-                  // color: 'white',
-                  // fontSize: 50 / fontScale,
-                }}>
-                <Text
-                  // .paranovel-headword
-                  style={{
-                    color: 'white',
-                    fontSize: 22 / fontScale,
-                  }}>
-                  {forms
-                    .filter(({ kana }) => !kana)
-                    .map(({ common, form }) => (common ? form : `（${form}）`))
-                    .join('、')}
-                </Text>
-                <Text
-                  // .paranovel-reading-item
-                  style={{
-                    color: 'white',
-                    fontSize: paranovelPopoverDefinitionFontSize,
-                  }}>
-                  {readings
-                    // Could represent uncommon using dice
-                    .map(({ common, form }) => (common ? form : `（${form}）`))
-                    .join('、')}
-                </Text>
-
-                <View
-                  // .paranovel-sense-list
-                  style={{ gap: 16 }}>
-                  {senses.map(({ pos, gloss }, i) => {
-                    return (
-                      <View
-                        key={i}
-                        // .paranovel-sense-item
-                        style={{
-                          alignItems: 'flex-start',
-                          gap: 8,
-                        }}>
-                        <View
-                          // .paranovel-pos-list
-                          style={{ flexDirection: 'row', gap: 8 }}>
-                          {pos.map((p, i) => (
-                            // .paranovel-pos-item
-                            <Text
-                              key={i}
-                              style={{
-                                color: 'white',
-                                borderWidth: 1,
-                                borderStyle: 'solid',
-                                borderColor: 'grey',
-                                borderRadius: 4,
-                                paddingLeft: 4,
-                                paddingRight: 4,
-                                fontSize: paranovelPopoverDefinitionFontSize,
-                              }}>
-                              {p}
-                            </Text>
-                          ))}
-                        </View>
-
-                        <Text
-                          // .paranovel-gloss-item
-                          style={{
-                            color: 'white',
-                            fontSize: paranovelPopoverDefinitionFontSize,
-                          }}>
-                          {`${i + 1}. ${gloss.join('; ')}`}
-                        </Text>
-                      </View>
-                    );
-                  })}
-                </View>
-              </View>
-            );
-          })}
-
-          <View
-            // .paranovel-show-more-container
+          <ScrollView
+            ref={scrollViewRef}
+            // #paranovel-popover-content
             style={{
-              // TODO: revisit styles for overscroll
-              display: withShowMoreButton ? 'flex' : 'none',
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: 34,
-              alignItems: 'center',
-              justifyContent: 'center',
-              /* TODO: base this on var(--paranovel-popover-background-color) */
-              backgroundColor: '#2228',
+              backgroundColor: 'black',
+              padding: 8,
+              boxSizing: 'border-box',
+              // It doesn't seem to be respecting this
+              // overflow: 'scroll',
+
+              // maxWidth: '100%',
+              // height: 'fit-content',
+              // maxHeight: '100%',
             }}>
-            <Pressable
+            {results.map(({ forms, senses }, i) => {
+              const readings = forms
+                .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))
+                .filter(({ kana }) => kana);
+
+              return (
+                <View
+                  key={i}
+                  // .paranovel-result-container
+                  style={{
+                    gap: 8,
+                    alignItems: 'stretch',
+                    maxWidth: '100%',
+
+                    // To be inherited:
+                    // color: 'white',
+                    // fontSize: 50 / fontScale,
+                  }}>
+                  <Text
+                    // .paranovel-headword
+                    style={{
+                      color: 'white',
+                      fontSize: 22 / fontScale,
+                    }}>
+                    {forms
+                      .filter(({ kana }) => !kana)
+                      .map(({ common, form }) =>
+                        common ? form : `（${form}）`,
+                      )
+                      .join('、')}
+                  </Text>
+                  <Text
+                    // .paranovel-reading-item
+                    style={{
+                      color: 'white',
+                      fontSize: paranovelPopoverDefinitionFontSize,
+                    }}>
+                    {readings
+                      // Could represent uncommon using dice
+                      .map(({ common, form }) =>
+                        common ? form : `（${form}）`,
+                      )
+                      .join('、')}
+                  </Text>
+
+                  <View
+                    // .paranovel-sense-list
+                    style={{ gap: 16 }}>
+                    {senses.map(({ pos, gloss }, i) => {
+                      return (
+                        <View
+                          key={i}
+                          // .paranovel-sense-item
+                          style={{
+                            alignItems: 'flex-start',
+                            gap: 8,
+                          }}>
+                          <View
+                            // .paranovel-pos-list
+                            style={{ flexDirection: 'row', gap: 8 }}>
+                            {pos.map((p, i) => (
+                              // .paranovel-pos-item
+                              <Text
+                                key={i}
+                                style={{
+                                  color: 'white',
+                                  borderWidth: 1,
+                                  borderStyle: 'solid',
+                                  borderColor: 'grey',
+                                  borderRadius: 4,
+                                  paddingLeft: 4,
+                                  paddingRight: 4,
+                                  fontSize: paranovelPopoverDefinitionFontSize,
+                                }}>
+                                {p}
+                              </Text>
+                            ))}
+                          </View>
+
+                          <Text
+                            // .paranovel-gloss-item
+                            style={{
+                              color: 'white',
+                              fontSize: paranovelPopoverDefinitionFontSize,
+                            }}>
+                            {`${i + 1}. ${gloss.join('; ')}`}
+                          </Text>
+                        </View>
+                      );
+                    })}
+                  </View>
+                </View>
+              );
+            })}
+
+            <View
+              // .paranovel-show-more-container
               style={{
-                backgroundColor: '#bbb',
-                borderRadius: 16,
-                paddingBlock: 2,
-                paddingInline: 16,
+                // TODO: revisit styles for overscroll
+                display: withShowMoreButton ? 'flex' : 'none',
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: 34,
+                alignItems: 'center',
+                justifyContent: 'center',
+                /* TODO: base this on var(--paranovel-popover-background-color) */
+                backgroundColor: '#2228',
               }}>
-              <Text style={{ color: '#111' }}>Show more</Text>
-            </Pressable>
-          </View>
-        </ScrollView>
-      </View>
+              <Pressable
+                style={{
+                  backgroundColor: '#bbb',
+                  borderRadius: 16,
+                  paddingBlock: 2,
+                  paddingInline: 16,
+                }}>
+                <Text style={{ color: '#111' }}>Show more</Text>
+              </Pressable>
+            </View>
+          </ScrollView>
+        </View>
+      )}
     </>
   );
 }

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -680,6 +680,9 @@ function NativePopover({
   const paranovelPopoverDefinitionFontSize = 14 / fontScale;
 
   const debugStyles: boolean = false;
+  const touchState = useRef<{ type: 'idle' } | { type: 'start' }>({
+    type: 'idle',
+  });
 
   return (
     <>
@@ -695,7 +698,7 @@ function NativePopover({
           left,
           display: debugStyles && visible ? 'flex' : 'none',
         }}></View>
-      <Pressable
+      <View
         // #paranovel-popover-stage
         ref={stageRef}
         style={{
@@ -707,151 +710,190 @@ function NativePopover({
           // ...stageStyles,
           display: visible ? 'flex' : 'none',
         }}
-        onPress={event => {
+        onTouchStart={({ nativeEvent: { pageX, pageY } }) => {
+          const rect = scrollViewRef.current
+            ?.getNativeScrollRef()
+            ?.getBoundingClientRect();
+          if (!rect) {
+            return;
+          }
+
+          const { top, right, bottom, left } = rect;
+          if (
+            pageX >= left &&
+            pageX <= right &&
+            pageY >= top &&
+            pageY <= bottom
+          ) {
+            // The touch upon the stage fell inside the ScrollView.
+            return;
+          }
+
+          touchState.current = { type: 'start' };
+        }}
+        onTouchCancel={() => {
+          touchState.current = { type: 'idle' };
+        }}
+        onTouchEnd={({ nativeEvent: { pageX, pageY } }) => {
+          const initialState = touchState.current;
+          touchState.current = { type: 'idle' };
+
+          if (initialState.type !== 'start') {
+            return;
+          }
+
+          const rect = scrollViewRef.current
+            ?.getNativeScrollRef()
+            ?.getBoundingClientRect();
+          if (!rect) {
+            return;
+          }
+
+          const { top, right, bottom, left } = rect;
+          if (
+            pageX >= left &&
+            pageX <= right &&
+            pageY >= top &&
+            pageY <= bottom
+          ) {
+            // The touch upon the stage fell inside the ScrollView.
+            return;
+          }
+
           closePopover();
         }}>
-        <Pressable
-          onPress={event => {
-            // The mere presence of the child Pressable effectively prevents the
-            // press event from bubbling to the parent Pressable.
+        <ScrollView
+          ref={scrollViewRef}
+          // #paranovel-popover-content
+          style={{
+            backgroundColor: 'black',
+            padding: 8,
+            boxSizing: 'border-box',
+            // It doesn't seem to be respecting this
+            // overflow: 'scroll',
+
+            // maxWidth: '100%',
+            // height: 'fit-content',
+            // maxHeight: '100%',
           }}>
-          <ScrollView
-            ref={scrollViewRef}
-            // #paranovel-popover-content
-            style={{
-              backgroundColor: 'black',
-              padding: 8,
-              boxSizing: 'border-box',
-              // It doesn't seem to be respecting this
-              // overflow: 'scroll',
+          {results.map(({ forms, senses }, i) => {
+            const readings = forms
+              .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))
+              .filter(({ kana }) => kana);
 
-              // maxWidth: '100%',
-              // height: 'fit-content',
-              // maxHeight: '100%',
-            }}>
-            {results.map(({ forms, senses }, i) => {
-              const readings = forms
-                .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))
-                .filter(({ kana }) => kana);
-
-              return (
-                <View
-                  key={i}
-                  // .paranovel-result-container
-                  style={{
-                    gap: 8,
-                    alignItems: 'stretch',
-                    maxWidth: '100%',
-
-                    // To be inherited:
-                    // color: 'white',
-                    // fontSize: 50 / fontScale,
-                  }}>
-                  <Text
-                    // .paranovel-headword
-                    style={{
-                      color: 'white',
-                      fontSize: 22 / fontScale,
-                    }}>
-                    {forms
-                      .filter(({ kana }) => !kana)
-                      .map(({ common, form }) =>
-                        common ? form : `（${form}）`,
-                      )
-                      .join('、')}
-                  </Text>
-                  <Text
-                    // .paranovel-reading-item
-                    style={{
-                      color: 'white',
-                      fontSize: paranovelPopoverDefinitionFontSize,
-                    }}>
-                    {readings
-                      // Could represent uncommon using dice
-                      .map(({ common, form }) =>
-                        common ? form : `（${form}）`,
-                      )
-                      .join('、')}
-                  </Text>
-
-                  <View
-                    // .paranovel-sense-list
-                    style={{ gap: 16 }}>
-                    {senses.map(({ pos, gloss }, i) => {
-                      return (
-                        <View
-                          key={i}
-                          // .paranovel-sense-item
-                          style={{
-                            alignItems: 'flex-start',
-                            gap: 8,
-                          }}>
-                          <View
-                            // .paranovel-pos-list
-                            style={{ flexDirection: 'row', gap: 8 }}>
-                            {pos.map((p, i) => (
-                              // .paranovel-pos-item
-                              <Text
-                                key={i}
-                                style={{
-                                  color: 'white',
-                                  borderWidth: 1,
-                                  borderStyle: 'solid',
-                                  borderColor: 'grey',
-                                  borderRadius: 4,
-                                  paddingLeft: 4,
-                                  paddingRight: 4,
-                                  fontSize: paranovelPopoverDefinitionFontSize,
-                                }}>
-                                {p}
-                              </Text>
-                            ))}
-                          </View>
-
-                          <Text
-                            // .paranovel-gloss-item
-                            style={{
-                              color: 'white',
-                              fontSize: paranovelPopoverDefinitionFontSize,
-                            }}>
-                            {`${i + 1}. ${gloss.join('; ')}`}
-                          </Text>
-                        </View>
-                      );
-                    })}
-                  </View>
-                </View>
-              );
-            })}
-
-            <View
-              // .paranovel-show-more-container
-              style={{
-                // TODO: revisit styles for overscroll
-                display: withShowMoreButton ? 'flex' : 'none',
-                position: 'absolute',
-                bottom: 0,
-                left: 0,
-                right: 0,
-                height: 34,
-                alignItems: 'center',
-                justifyContent: 'center',
-                /* TODO: base this on var(--paranovel-popover-background-color) */
-                backgroundColor: '#2228',
-              }}>
-              <Pressable
+            return (
+              <View
+                key={i}
+                // .paranovel-result-container
                 style={{
-                  backgroundColor: '#bbb',
-                  borderRadius: 16,
-                  paddingBlock: 2,
-                  paddingInline: 16,
+                  gap: 8,
+                  alignItems: 'stretch',
+                  maxWidth: '100%',
+
+                  // To be inherited:
+                  // color: 'white',
+                  // fontSize: 50 / fontScale,
                 }}>
-                <Text style={{ color: '#111' }}>Show more</Text>
-              </Pressable>
-            </View>
-          </ScrollView>
-        </Pressable>
-      </Pressable>
+                <Text
+                  // .paranovel-headword
+                  style={{
+                    color: 'white',
+                    fontSize: 22 / fontScale,
+                  }}>
+                  {forms
+                    .filter(({ kana }) => !kana)
+                    .map(({ common, form }) => (common ? form : `（${form}）`))
+                    .join('、')}
+                </Text>
+                <Text
+                  // .paranovel-reading-item
+                  style={{
+                    color: 'white',
+                    fontSize: paranovelPopoverDefinitionFontSize,
+                  }}>
+                  {readings
+                    // Could represent uncommon using dice
+                    .map(({ common, form }) => (common ? form : `（${form}）`))
+                    .join('、')}
+                </Text>
+
+                <View
+                  // .paranovel-sense-list
+                  style={{ gap: 16 }}>
+                  {senses.map(({ pos, gloss }, i) => {
+                    return (
+                      <View
+                        key={i}
+                        // .paranovel-sense-item
+                        style={{
+                          alignItems: 'flex-start',
+                          gap: 8,
+                        }}>
+                        <View
+                          // .paranovel-pos-list
+                          style={{ flexDirection: 'row', gap: 8 }}>
+                          {pos.map((p, i) => (
+                            // .paranovel-pos-item
+                            <Text
+                              key={i}
+                              style={{
+                                color: 'white',
+                                borderWidth: 1,
+                                borderStyle: 'solid',
+                                borderColor: 'grey',
+                                borderRadius: 4,
+                                paddingLeft: 4,
+                                paddingRight: 4,
+                                fontSize: paranovelPopoverDefinitionFontSize,
+                              }}>
+                              {p}
+                            </Text>
+                          ))}
+                        </View>
+
+                        <Text
+                          // .paranovel-gloss-item
+                          style={{
+                            color: 'white',
+                            fontSize: paranovelPopoverDefinitionFontSize,
+                          }}>
+                          {`${i + 1}. ${gloss.join('; ')}`}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+            );
+          })}
+
+          <View
+            // .paranovel-show-more-container
+            style={{
+              // TODO: revisit styles for overscroll
+              display: withShowMoreButton ? 'flex' : 'none',
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              height: 34,
+              alignItems: 'center',
+              justifyContent: 'center',
+              /* TODO: base this on var(--paranovel-popover-background-color) */
+              backgroundColor: '#2228',
+            }}>
+            <Pressable
+              style={{
+                backgroundColor: '#bbb',
+                borderRadius: 16,
+                paddingBlock: 2,
+                paddingInline: 16,
+              }}>
+              <Text style={{ color: '#111' }}>Show more</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </View>
     </>
   );
 }

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -10,11 +10,17 @@ import React, {
 } from 'react';
 import {
   Button,
+  Dimensions,
   SafeAreaView,
+  StyleProp,
   StyleSheet,
   TouchableOpacity,
   useColorScheme,
   View,
+  ViewStyle,
+  Text,
+  Pressable,
+  ScrollView,
 } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 
@@ -518,30 +524,314 @@ export default function BookScreen({
 }
 
 function NativePopover({ state }: { state: NativePopupState }) {
-  const {
-    visible,
-    anchorRect: { top, left, width, height },
-    results,
-  } = state;
+  const { visible, anchorRect, results } = state;
+  const { top, left, width, height } = anchorRect;
+
+  const [withShowMoreButton, _setWithShowMoreButton] = useState(false);
 
   console.log('AHOY', state.anchorRect);
 
   // Currently we're reflecting the anchorRect.
   // TODO: see layOutPopover() in `src/source-assets/injected-javascript.wvjs`
   //       and run the multi-try `tryOrientation()` .
+
+  const stageStyles = tryOrientation({ anchorRect, orientation: 'left' });
+
+  const fontScale = 1;
+  const paranovelPopoverDefinitionFontSize = 14 / fontScale;
+
   return (
-    <View
-      style={{
-        backgroundColor: 'cyan',
-        width,
-        height,
-        top,
-        left,
-        position: 'absolute',
-        display: visible ? 'flex' : 'none',
-      }}></View>
+    <>
+      <View
+        // #paranovel-anchor
+        style={{
+          position: 'absolute',
+          pointerEvents: 'none',
+          backgroundColor: 'cyan',
+          width,
+          height,
+          top,
+          left,
+          display: visible ? 'flex' : 'none',
+        }}></View>
+      <View
+        // #paranovel-popover-stage
+        style={{
+          position: 'absolute',
+          backgroundColor: 'rgba(255,255,0,0.5)',
+          inset: 0,
+          padding: 16,
+          alignItems: 'center',
+          ...stageStyles,
+          display: visible ? 'flex' : 'none',
+        }}>
+        <ScrollView
+          // #paranovel-popover-content
+          style={{
+            backgroundColor: 'black',
+            padding: 8,
+            boxSizing: 'border-box',
+            // It doesn't seem to be respecting this
+            // overflow: 'scroll',
+
+            // maxWidth: '100%',
+            // height: 'fit-content',
+            // maxHeight: '100%',
+          }}>
+          {results.map(({ forms, senses }, i) => {
+            const readings = forms
+              .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))
+              .filter(({ kana }) => kana);
+
+            return (
+              <View
+                key={i}
+                // .paranovel-result-container
+                style={{
+                  gap: 8,
+                  alignItems: 'stretch',
+                  maxWidth: '100%',
+
+                  // To be inherited:
+                  // color: 'white',
+                  // fontSize: 50 / fontScale,
+                }}>
+                <Text
+                  // .paranovel-headword
+                  style={{
+                    color: 'white',
+                    fontSize: 22 / fontScale,
+                  }}>
+                  {forms
+                    .filter(({ kana }) => !kana)
+                    .map(({ common, form }) => (common ? form : `（${form}）`))
+                    .join('、')}
+                </Text>
+                <Text
+                  // .paranovel-reading-item
+                  style={{
+                    color: 'white',
+                    fontSize: paranovelPopoverDefinitionFontSize,
+                  }}>
+                  {readings
+                    // Could represent uncommon using dice
+                    .map(({ common, form }) => (common ? form : `（${form}）`))
+                    .join('、')}
+                </Text>
+
+                <View
+                  // .paranovel-sense-list
+                  style={{ gap: 16 }}>
+                  {senses.map(({ pos, gloss }, i) => {
+                    return (
+                      <View
+                        key={i}
+                        // .paranovel-sense-item
+                        style={{
+                          alignItems: 'flex-start',
+                          gap: 8,
+                        }}>
+                        <View
+                          // .paranovel-pos-list
+                          style={{ flexDirection: 'row', gap: 8 }}>
+                          {pos.map((p, i) => (
+                            // .paranovel-pos-item
+                            <Text
+                              key={i}
+                              style={{
+                                color: 'white',
+                                borderWidth: 1,
+                                borderStyle: 'solid',
+                                borderColor: 'grey',
+                                borderRadius: 4,
+                                paddingLeft: 4,
+                                paddingRight: 4,
+                                fontSize: paranovelPopoverDefinitionFontSize,
+                              }}>
+                              {p}
+                            </Text>
+                          ))}
+                        </View>
+
+                        <Text
+                          // .paranovel-gloss-item
+                          style={{
+                            color: 'white',
+                            fontSize: paranovelPopoverDefinitionFontSize,
+                          }}>
+                          {`${i + 1}. ${gloss.join('; ')}`}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+            );
+          })}
+
+          <View
+            // .paranovel-show-more-container
+            style={{
+              // TODO: revisit styles for overscroll
+              display: withShowMoreButton ? 'flex' : 'none',
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              height: 34,
+              alignItems: 'center',
+              justifyContent: 'center',
+              /* TODO: base this on var(--paranovel-popover-background-color) */
+              backgroundColor: '#2228',
+            }}>
+            <Pressable
+              style={{
+                backgroundColor: '#bbb',
+                borderRadius: 16,
+                paddingBlock: 2,
+                paddingInline: 16,
+              }}>
+              <Text style={{ color: '#111' }}>Show more</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </View>
+    </>
   );
 }
+
+function tryOrientation({
+  anchorRect,
+  orientation,
+}: {
+  anchorRect: Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'>;
+  orientation: Orientation;
+}): StyleProp<ViewStyle> {
+  // `anchorRect` is measured entirely from the top-left (i.e. `bottom` is the
+  // number of pixels down from the top; it's equivalent to `top` + `height`).
+  const { top, left, bottom, right } = anchorRect;
+
+  // popoverStage.style.removeProperty('top');
+  // popoverStage.style.removeProperty('right');
+  // popoverStage.style.removeProperty('bottom');
+  // popoverStage.style.removeProperty('left');
+
+  // /**
+  //  * For now, the popover is always formatted as horizontal-lr, even if the
+  //  * ebook is vertical-rl. This is, in chief, because I'm starting with a
+  //  * Japanese-English dictionary, and vertical-rl does not suit English text.
+  //  */
+  // const popoverWritingDirectionMatchesBodyText = false;
+
+  // let blockOverflow = 0;
+  // let inlineOverflow = 0;
+  // let clientBlockSize = 0;
+  // let clientInlineSize = 0;
+
+  // const windowInnerHeight =
+
+  switch (orientation) {
+    case 'top': {
+      return {
+        flexDirection: 'column',
+        justifyContent: 'flex-end',
+        bottom: Dimensions.get('window').height - top,
+      };
+
+      // blockOverflow = popoverContent.scrollHeight - popoverContent.clientHeight;
+      // inlineOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
+      // clientBlockSize = popoverContent.clientHeight;
+      // clientInlineSize = popoverContent.clientWidth;
+      // break;
+    }
+    case 'right': {
+      return {
+        flexDirection: 'row',
+        justifyContent: 'flex-start',
+        left: right,
+      };
+      // if (popoverWritingDirectionMatchesBodyText) {
+      //   blockOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
+      //   inlineOverflow =
+      //     popoverContent.scrollHeight - popoverContent.clientHeight;
+      //   clientBlockSize = popoverContent.clientWidth;
+      //   clientInlineSize = popoverContent.clientHeight;
+      // } else {
+      //   blockOverflow =
+      //     popoverContent.scrollHeight - popoverContent.clientHeight;
+      //   inlineOverflow =
+      //     popoverContent.scrollWidth - popoverContent.clientWidth;
+      //   clientBlockSize = popoverContent.clientHeight;
+      //   clientInlineSize = popoverContent.clientWidth;
+      // }
+      // break;
+    }
+    case 'bottom': {
+      return {
+        flexDirection: 'column',
+        justifyContent: 'flex-start',
+        left: bottom,
+      };
+
+      // blockOverflow = popoverContent.scrollHeight - popoverContent.clientHeight;
+      // inlineOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
+      // clientBlockSize = popoverContent.clientHeight;
+      // clientInlineSize = popoverContent.clientWidth;
+      // break;
+    }
+    case 'left': {
+      return {
+        flexDirection: 'row',
+        justifyContent: 'flex-end',
+        right: Dimensions.get('window').width - left,
+      };
+
+      // popoverStage.style.flexDirection = 'row';
+      // popoverStage.style.justifyContent = 'flex-end';
+      // popoverStage.style.right = `${window.innerWidth - left}px`;
+      // if (popoverWritingDirectionMatchesBodyText) {
+      //   blockOverflow = popoverContent.scrollWidth - popoverContent.clientWidth;
+      //   inlineOverflow =
+      //     popoverContent.scrollHeight - popoverContent.clientHeight;
+      //   clientBlockSize = popoverContent.clientWidth;
+      //   clientInlineSize = popoverContent.clientHeight;
+      // } else {
+      //   blockOverflow =
+      //     popoverContent.scrollHeight - popoverContent.clientHeight;
+      //   inlineOverflow =
+      //     popoverContent.scrollWidth - popoverContent.clientWidth;
+      //   clientBlockSize = popoverContent.clientHeight;
+      //   clientInlineSize = popoverContent.clientWidth;
+      // }
+      // break;
+    }
+  }
+
+  // const stageRect = popoverContent.getBoundingClientRect();
+
+  // // Although the anchor may be fully onscreen, some orientations around it may
+  // // cause the popover to fall offscreen.
+  // let isOverflowingViewport = false;
+  // if (
+  //   stageRect.top < 0 ||
+  //   stageRect.left < 0 ||
+  //   stageRect.bottom > window.innerHeight ||
+  //   stageRect.right > window.innerWidth
+  // ) {
+  //   isOverflowingViewport = true;
+  // }
+
+  // return {
+  //   blockOverflow,
+  //   inlineOverflow,
+  //   clientBlockSize,
+  //   clientInlineSize,
+  //   isOverflowingViewport,
+  //   stageRect,
+  // };
+}
+
+type Orientation = 'top' | 'right' | 'bottom' | 'left';
 
 interface NativePopupState {
   visible: boolean;
@@ -760,6 +1050,11 @@ function onMessage({
         anchorRect,
         results,
       } = parsed;
+      console.log(`[WebView] present-native-popover`, {
+        positionTryOrder,
+        anchorRect,
+        results,
+      });
       setNativePopup({ visible: true, anchorRect, results });
       return;
     }

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -760,6 +760,11 @@ function NativePopover({
             return;
           }
 
+          // FIXME: The scroll offset from previous render will persist.
+          // Both scrollTo() and setNativeProps(), are getting ignored.
+          // We may need to remove it from the view tree altogether (rather than
+          // setting `display: none`) just to reset the state.
+
           closePopover();
         }}>
         <ScrollView

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -355,6 +355,7 @@ export default function BookScreen({
         webviewDebuggingEnabled={true}
         javaScriptEnabled={true}
         onMessage={onMessageCallback}
+        allowsBackForwardNavigationGestures={false}
         style={{
           backgroundColor: scheme === 'dark' ? 'black' : 'white',
         }}
@@ -522,12 +523,32 @@ export default function BookScreen({
           return false;
         }}
       />
-      <NativePopover state={nativePopup} />
+      <NativePopover
+        state={nativePopup}
+        closePopover={() => {
+          setNativePopup(prev => ({
+            ...prev,
+            visible: false,
+          }));
+          // The webViewRef.current?.postMessage() API is fake. Under the hood, it
+          // just calls injectJavaScript() and dispatches a MessageEvent at the
+          // window.
+          webViewRef.current?.injectJavaScript(
+            `console.log('!! close-native-popover', window.__paranovelState); if(window.__paranovelState) {\n  window.__paranovelState.nativeModalVisible = false; __paranovelState.wordHighlight.clear(); __paranovelState.rtIsolationHack?.remove(); \n}`,
+          );
+        }}
+      />
     </SafeAreaView>
   );
 }
 
-function NativePopover({ state }: { state: NativePopupState }) {
+function NativePopover({
+  state,
+  closePopover,
+}: {
+  state: NativePopupState;
+  closePopover: () => void;
+}) {
   const { visible, anchorRect, results, positionTryOrder } = state;
   const { top, left, width, height } = anchorRect;
   const [withShowMoreButton, _setWithShowMoreButton] = useState(false);
@@ -658,6 +679,8 @@ function NativePopover({ state }: { state: NativePopupState }) {
   const fontScale = 1;
   const paranovelPopoverDefinitionFontSize = 14 / fontScale;
 
+  const debugStyles: boolean = false;
+
   return (
     <>
       <View
@@ -670,152 +693,165 @@ function NativePopover({ state }: { state: NativePopupState }) {
           height,
           top,
           left,
-          display: visible ? 'flex' : 'none',
+          display: debugStyles && visible ? 'flex' : 'none',
         }}></View>
-      <View
+      <Pressable
         // #paranovel-popover-stage
         ref={stageRef}
         style={{
           position: 'absolute',
-          backgroundColor: 'rgba(255,255,0,0.5)',
+          backgroundColor: debugStyles ? 'rgba(255,255,0,0.5)' : undefined,
           inset: 0,
           padding: 16,
           alignItems: 'center',
           // ...stageStyles,
           display: visible ? 'flex' : 'none',
+        }}
+        onPress={event => {
+          closePopover();
         }}>
-        <ScrollView
-          ref={scrollViewRef}
-          // #paranovel-popover-content
-          style={{
-            backgroundColor: 'black',
-            padding: 8,
-            boxSizing: 'border-box',
-            // It doesn't seem to be respecting this
-            // overflow: 'scroll',
-
-            // maxWidth: '100%',
-            // height: 'fit-content',
-            // maxHeight: '100%',
+        <Pressable
+          onPress={event => {
+            // The mere presence of the child Pressable effectively prevents the
+            // press event from bubbling to the parent Pressable.
           }}>
-          {results.map(({ forms, senses }, i) => {
-            const readings = forms
-              .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))
-              .filter(({ kana }) => kana);
-
-            return (
-              <View
-                key={i}
-                // .paranovel-result-container
-                style={{
-                  gap: 8,
-                  alignItems: 'stretch',
-                  maxWidth: '100%',
-
-                  // To be inherited:
-                  // color: 'white',
-                  // fontSize: 50 / fontScale,
-                }}>
-                <Text
-                  // .paranovel-headword
-                  style={{
-                    color: 'white',
-                    fontSize: 22 / fontScale,
-                  }}>
-                  {forms
-                    .filter(({ kana }) => !kana)
-                    .map(({ common, form }) => (common ? form : `（${form}）`))
-                    .join('、')}
-                </Text>
-                <Text
-                  // .paranovel-reading-item
-                  style={{
-                    color: 'white',
-                    fontSize: paranovelPopoverDefinitionFontSize,
-                  }}>
-                  {readings
-                    // Could represent uncommon using dice
-                    .map(({ common, form }) => (common ? form : `（${form}）`))
-                    .join('、')}
-                </Text>
-
-                <View
-                  // .paranovel-sense-list
-                  style={{ gap: 16 }}>
-                  {senses.map(({ pos, gloss }, i) => {
-                    return (
-                      <View
-                        key={i}
-                        // .paranovel-sense-item
-                        style={{
-                          alignItems: 'flex-start',
-                          gap: 8,
-                        }}>
-                        <View
-                          // .paranovel-pos-list
-                          style={{ flexDirection: 'row', gap: 8 }}>
-                          {pos.map((p, i) => (
-                            // .paranovel-pos-item
-                            <Text
-                              key={i}
-                              style={{
-                                color: 'white',
-                                borderWidth: 1,
-                                borderStyle: 'solid',
-                                borderColor: 'grey',
-                                borderRadius: 4,
-                                paddingLeft: 4,
-                                paddingRight: 4,
-                                fontSize: paranovelPopoverDefinitionFontSize,
-                              }}>
-                              {p}
-                            </Text>
-                          ))}
-                        </View>
-
-                        <Text
-                          // .paranovel-gloss-item
-                          style={{
-                            color: 'white',
-                            fontSize: paranovelPopoverDefinitionFontSize,
-                          }}>
-                          {`${i + 1}. ${gloss.join('; ')}`}
-                        </Text>
-                      </View>
-                    );
-                  })}
-                </View>
-              </View>
-            );
-          })}
-
-          <View
-            // .paranovel-show-more-container
+          <ScrollView
+            ref={scrollViewRef}
+            // #paranovel-popover-content
             style={{
-              // TODO: revisit styles for overscroll
-              display: withShowMoreButton ? 'flex' : 'none',
-              position: 'absolute',
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: 34,
-              alignItems: 'center',
-              justifyContent: 'center',
-              /* TODO: base this on var(--paranovel-popover-background-color) */
-              backgroundColor: '#2228',
+              backgroundColor: 'black',
+              padding: 8,
+              boxSizing: 'border-box',
+              // It doesn't seem to be respecting this
+              // overflow: 'scroll',
+
+              // maxWidth: '100%',
+              // height: 'fit-content',
+              // maxHeight: '100%',
             }}>
-            <Pressable
+            {results.map(({ forms, senses }, i) => {
+              const readings = forms
+                .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))
+                .filter(({ kana }) => kana);
+
+              return (
+                <View
+                  key={i}
+                  // .paranovel-result-container
+                  style={{
+                    gap: 8,
+                    alignItems: 'stretch',
+                    maxWidth: '100%',
+
+                    // To be inherited:
+                    // color: 'white',
+                    // fontSize: 50 / fontScale,
+                  }}>
+                  <Text
+                    // .paranovel-headword
+                    style={{
+                      color: 'white',
+                      fontSize: 22 / fontScale,
+                    }}>
+                    {forms
+                      .filter(({ kana }) => !kana)
+                      .map(({ common, form }) =>
+                        common ? form : `（${form}）`,
+                      )
+                      .join('、')}
+                  </Text>
+                  <Text
+                    // .paranovel-reading-item
+                    style={{
+                      color: 'white',
+                      fontSize: paranovelPopoverDefinitionFontSize,
+                    }}>
+                    {readings
+                      // Could represent uncommon using dice
+                      .map(({ common, form }) =>
+                        common ? form : `（${form}）`,
+                      )
+                      .join('、')}
+                  </Text>
+
+                  <View
+                    // .paranovel-sense-list
+                    style={{ gap: 16 }}>
+                    {senses.map(({ pos, gloss }, i) => {
+                      return (
+                        <View
+                          key={i}
+                          // .paranovel-sense-item
+                          style={{
+                            alignItems: 'flex-start',
+                            gap: 8,
+                          }}>
+                          <View
+                            // .paranovel-pos-list
+                            style={{ flexDirection: 'row', gap: 8 }}>
+                            {pos.map((p, i) => (
+                              // .paranovel-pos-item
+                              <Text
+                                key={i}
+                                style={{
+                                  color: 'white',
+                                  borderWidth: 1,
+                                  borderStyle: 'solid',
+                                  borderColor: 'grey',
+                                  borderRadius: 4,
+                                  paddingLeft: 4,
+                                  paddingRight: 4,
+                                  fontSize: paranovelPopoverDefinitionFontSize,
+                                }}>
+                                {p}
+                              </Text>
+                            ))}
+                          </View>
+
+                          <Text
+                            // .paranovel-gloss-item
+                            style={{
+                              color: 'white',
+                              fontSize: paranovelPopoverDefinitionFontSize,
+                            }}>
+                            {`${i + 1}. ${gloss.join('; ')}`}
+                          </Text>
+                        </View>
+                      );
+                    })}
+                  </View>
+                </View>
+              );
+            })}
+
+            <View
+              // .paranovel-show-more-container
               style={{
-                backgroundColor: '#bbb',
-                borderRadius: 16,
-                paddingBlock: 2,
-                paddingInline: 16,
+                // TODO: revisit styles for overscroll
+                display: withShowMoreButton ? 'flex' : 'none',
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: 34,
+                alignItems: 'center',
+                justifyContent: 'center',
+                /* TODO: base this on var(--paranovel-popover-background-color) */
+                backgroundColor: '#2228',
               }}>
-              <Text style={{ color: '#111' }}>Show more</Text>
-            </Pressable>
-          </View>
-        </ScrollView>
-      </View>
+              <Pressable
+                style={{
+                  backgroundColor: '#bbb',
+                  borderRadius: 16,
+                  paddingBlock: 2,
+                  paddingInline: 16,
+                }}>
+                <Text style={{ color: '#111' }}>Show more</Text>
+              </Pressable>
+            </View>
+          </ScrollView>
+        </Pressable>
+      </Pressable>
     </>
   );
 }
@@ -1102,6 +1138,9 @@ function onMessage({
     positionTryOrder: ['bottom', 'top'] | ['right', 'left'] | ['left', 'right'];
     results: Array<LookupResult>;
   }
+  interface CloseNativePayloadPayload {
+    type: 'close-native-popover';
+  }
   interface TokenizePayload {
     type: 'tokenize';
     id: number;
@@ -1123,6 +1162,7 @@ function onMessage({
     | LogPayload
     | LookUpPayload
     | PresentNativePayloadPayload
+    | CloseNativePayloadPayload
     | TokenizePayload
     | NavigationRequestPayload
     | ProgressPayload;
@@ -1216,6 +1256,24 @@ function onMessage({
         positionTryOrder,
         writingMode,
       });
+      webViewRef.current?.injectJavaScript(
+        `console.log('!! present-native-popover', window.__paranovelState); if(window.__paranovelState) {\n  window.__paranovelState.nativeModalVisible = true;\n}`,
+      );
+      return;
+    }
+    case 'close-native-popover': {
+      console.log(`[WebView] close-native-popover`);
+      setNativePopup(prev => ({
+        ...prev,
+        visible: false,
+      }));
+
+      // The webViewRef.current?.postMessage() API is fake. Under the hood, it
+      // just calls injectJavaScript() and dispatches a MessageEvent at the
+      // window. So we won't bother with an IPC channel in this direction.
+      webViewRef.current?.injectJavaScript(
+        `console.log('!! close-native-popover', window.__paranovelState); if(window.__paranovelState) {\n  window.__paranovelState.nativeModalVisible = false; __paranovelState.wordHighlight.clear(); __paranovelState.rtIsolationHack?.remove(); \n}`,
+      );
       return;
     }
     case 'navigation-request': {

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -776,6 +776,19 @@ function NativePopover({
               // maxHeight: '100%',
               minWidth: 100,
             }}>
+            {!results.length && (
+              <Text
+                style={{
+                  // Can't identify why, but "No results" always fills the full
+                  // width. There's nothing like `inline-size: fit-content`.
+                  textAlign: 'center',
+                  color: 'white',
+                  fontSize: paranovelPopoverDefinitionFontSize,
+                }}>
+                No results.
+              </Text>
+            )}
+
             {results.map(({ forms, senses }, i) => {
               const readings = forms
                 .sort((a, b) => (b.common ? 1 : 0) - (a.common ? 1 : 0))

--- a/src/book-screen.tsx
+++ b/src/book-screen.tsx
@@ -310,6 +310,8 @@ export default function BookScreen({
       width: 0,
       height: 0,
     },
+    writingMode: 'horizontal-tb',
+    positionTryOrder: ['bottom', 'top'],
     results: [],
   });
 
@@ -520,23 +522,17 @@ export default function BookScreen({
           return false;
         }}
       />
-      <NativePopover state={nativePopup} writingMode="vertical-rl" />
+      <NativePopover state={nativePopup} />
     </SafeAreaView>
   );
 }
 
-function NativePopover({
-  state,
-  writingMode = 'horizontal-tb',
-}: {
-  state: NativePopupState;
-  writingMode?: string;
-}) {
-  const { visible, anchorRect, results } = state;
+function NativePopover({ state }: { state: NativePopupState }) {
+  const { visible, anchorRect, results, positionTryOrder } = state;
   const { top, left, width, height } = anchorRect;
   const [withShowMoreButton, _setWithShowMoreButton] = useState(false);
 
-  const positionTryOrder = getBestPositionTryOrder(writingMode);
+  // const positionTryOrder = getBestPositionTryOrder(writingMode);
 
   console.log('AHOY', results);
 
@@ -1032,6 +1028,13 @@ interface NativePopupState {
     width: number;
     height: number;
   };
+  writingMode:
+    | 'horizontal-tb'
+    | 'vertical-rl'
+    | 'vertical-lr'
+    | 'sideways-lr'
+    | 'sideways-rl';
+  positionTryOrder: ['bottom', 'top'] | ['right', 'left'] | ['left', 'right'];
   results: Array<LookupResult>;
 }
 
@@ -1133,6 +1136,12 @@ function onMessage({
     type: 'present-native-popover';
     id: number;
     anchorRect: DOMRect;
+    writingMode:
+      | 'horizontal-tb'
+      | 'vertical-rl'
+      | 'vertical-lr'
+      | 'sideways-lr'
+      | 'sideways-rl';
     positionTryOrder: ['bottom', 'top'] | ['right', 'left'] | ['left', 'right'];
     results: Array<LookupResult>;
   }
@@ -1236,13 +1245,20 @@ function onMessage({
         positionTryOrder,
         anchorRect,
         results,
+        writingMode,
       } = parsed;
       console.log(`[WebView] present-native-popover`, {
         positionTryOrder,
         anchorRect,
         results,
       });
-      setNativePopup({ visible: true, anchorRect, results });
+      setNativePopup({
+        visible: true,
+        anchorRect,
+        results,
+        positionTryOrder,
+        writingMode,
+      });
       return;
     }
     case 'navigation-request': {

--- a/src/navigation.tsx
+++ b/src/navigation.tsx
@@ -24,7 +24,11 @@ export function RootStack() {
         component={LibraryScreen}
         options={{ headerShown: false, headerTitle: 'Library' }}
       />
-      <Stack.Screen name="Book" component={BookScreen} />
+      <Stack.Screen
+        name="Book"
+        component={BookScreen}
+        options={{ gestureEnabled: false }}
+      />
       <Stack.Screen name="ToC" component={ToCScreen} />
     </Stack.Navigator>
   );

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -43,7 +43,7 @@ function updatePopover({ results, tokenRange, transactionId }) {
    * would have equally worked:
    * @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
    */
-  const rtIsolationHack = {
+  __paranovelState.rtIsolationHack = {
     // It would be more intuitive to opt in to isolation rather than opt out,
     // but opting in leads to a visible flash on the anchor <rt>.
     apply: () => {
@@ -86,7 +86,7 @@ function updatePopover({ results, tokenRange, transactionId }) {
   // about it scrolling along with the page.
 
   document.body.classList.add('modal');
-  rtIsolationHack.apply();
+  __paranovelState.rtIsolationHack.apply();
 
   const anchorRect = getEffectiveBoundingClientRect(tokenRange);
   console.log(
@@ -273,29 +273,29 @@ function updatePopover({ results, tokenRange, transactionId }) {
 
   popoverContent.scrollTop = 0;
   popover.style.setProperty('visibility', 'visible');
+}
 
-  /** @param {MouseEvent} event */
-  function onClose(event) {
-    const popover = document.getElementById('paranovel-popover');
-    const popoverContent = document.getElementById('paranovel-popover-content');
+/** @param {MouseEvent} event */
+function onClose(event) {
+  const popover = document.getElementById('paranovel-popover');
+  const popoverContent = document.getElementById('paranovel-popover-content');
 
-    if (popoverContent?.contains(event.target)) {
-      console.log('contained', event.currentTarget);
-      return;
-    }
-    console.log('out!');
-
-    if (popover) {
-      delete popover.dataset.open;
-    }
-    __paranovelState.wordHighlight.clear();
-    rtIsolationHack.remove();
-
-    // Stop this click propagating to the document-level click handler.
-    event.stopPropagation();
-
-    document.body.classList.remove('modal');
+  if (popoverContent?.contains(event.target)) {
+    console.log('contained', event.currentTarget);
+    return;
   }
+  console.log('out!');
+
+  if (popover) {
+    delete popover.dataset.open;
+  }
+  __paranovelState.wordHighlight.clear();
+  __paranovelState.rtIsolationHack?.remove();
+
+  // Stop this click propagating to the document-level click handler.
+  event.stopPropagation();
+
+  document.body.classList.remove('modal');
 }
 
 /**
@@ -1412,10 +1412,12 @@ function restoreScroll() {
   }
 }
 
+/** @type {{ wordHighlight: Highlight; tokenizationPromiseCount: number; tokenizationPromiseHandlers: Record<number, { resolve: () => void; reject: (reason?: any) => void; }>; rtIsolationHack: { apply: () => void; remove: () => void; } | undefined }} */
 const __paranovelState = {
   wordHighlight: new Highlight(),
   tokenizationPromiseCount: 0,
   tokenizationPromiseHandlers: {},
+  rtIsolationHack: undefined,
 };
 
 /**

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -200,12 +200,14 @@ function updatePopover({ results, tokenRange, transactionId }) {
     transactionId,
     results,
   });
+
   if (!orientation) {
     onClose();
     return;
   }
-  popoverContent.scrollTop = 0;
-  popover.style.setProperty('visibility', 'visible');
+
+  // popoverContent.scrollTop = 0;
+  // popover.style.setProperty('visibility', 'visible');
 
   /** @param {MouseEvent} event */
   function onClose(event) {
@@ -299,28 +301,13 @@ function layOutPopover({
     }
   }
 
-  const payload = {
-    id: transactionId,
-    positionTryOrder,
-    anchorRect: {
-      top: anchorRect.top,
-      right: anchorRect.right,
-      left: anchorRect.left,
-      bottom: anchorRect.bottom,
-      x: anchorRect.x,
-      y: anchorRect.y,
-      width: anchorRect.width,
-      height: anchorRect.height,
-    },
-    results: results ?? [],
-  };
-
   // TODO: Return here?
   window.ReactNativeWebView.postMessage(
     JSON.stringify({
       type: 'present-native-popover',
       id: transactionId,
       positionTryOrder,
+      writingMode,
       anchorRect: {
         top: anchorRect.top,
         right: anchorRect.right,
@@ -335,87 +322,87 @@ function layOutPopover({
     }),
   );
 
-  /** @type {Array<{ orientation: Orientation, blockOverflow: number, clientInlineSize: number }>} */
-  const solutions = [];
-  /** @type {Orientation} */
-  let lastTried;
-  for (const orientation of positionTryOrder) {
-    lastTried = orientation;
-    const {
-      blockOverflow,
-      inlineOverflow,
-      clientInlineSize,
-      isOverflowingViewport,
-      stageRect,
-    } = tryOrientation({
-      popoverStage,
-      popoverContent,
-      anchorRect,
-      orientation,
-    });
+  // /** @type {Array<{ orientation: Orientation, blockOverflow: number, clientInlineSize: number }>} */
+  // const solutions = [];
+  // /** @type {Orientation} */
+  // let lastTried;
+  // for (const orientation of positionTryOrder) {
+  //   lastTried = orientation;
+  //   const {
+  //     blockOverflow,
+  //     inlineOverflow,
+  //     clientInlineSize,
+  //     isOverflowingViewport,
+  //     stageRect,
+  //   } = tryOrientation({
+  //     popoverStage,
+  //     popoverContent,
+  //     anchorRect,
+  //     orientation,
+  //   });
 
-    if (isOverflowingViewport) {
-      console.log(
-        `Discarding orientation "${orientation}" as it's overflowing the viewport.`,
-        stageRect,
-      );
-      continue;
-    }
-    if (inlineOverflow) {
-      console.log(
-        `Discarding orientation "${orientation}" as it's overflowing in the inline orientation.`,
-        stageRect,
-      );
-      continue;
-    }
+  //   if (isOverflowingViewport) {
+  //     console.log(
+  //       `Discarding orientation "${orientation}" as it's overflowing the viewport.`,
+  //       stageRect,
+  //     );
+  //     continue;
+  //   }
+  //   if (inlineOverflow) {
+  //     console.log(
+  //       `Discarding orientation "${orientation}" as it's overflowing in the inline orientation.`,
+  //       stageRect,
+  //     );
+  //     continue;
+  //   }
 
-    solutions.push({ orientation, blockOverflow, clientInlineSize });
-  }
+  //   solutions.push({ orientation, blockOverflow, clientInlineSize });
+  // }
 
-  const sortedSolutions = solutions.sort((a, b) => {
-    // Sort in descending order of inline size.
-    const clientInlineSize = b.clientInlineSize - a.clientInlineSize;
+  // const sortedSolutions = solutions.sort((a, b) => {
+  //   // Sort in descending order of inline size.
+  //   const clientInlineSize = b.clientInlineSize - a.clientInlineSize;
 
-    // If there's no tie, use that alone as the sorting factor.
-    if (clientInlineSize) {
-      return clientInlineSize;
-    }
+  //   // If there's no tie, use that alone as the sorting factor.
+  //   if (clientInlineSize) {
+  //     return clientInlineSize;
+  //   }
 
-    // Otherwise, sort in ascending order of block overflow.
-    //
-    // (Given that we reserve the same amount of block space for both
-    // orientations, though, this won't actually make any difference unless we
-    // change the layout algorithm in future.)
-    return a.blockOverflow - b.blockOverflow;
-  });
-  const bestSolution = sortedSolutions.at(0)?.orientation;
+  //   // Otherwise, sort in ascending order of block overflow.
+  //   //
+  //   // (Given that we reserve the same amount of block space for both
+  //   // orientations, though, this won't actually make any difference unless we
+  //   // change the layout algorithm in future.)
+  //   return a.blockOverflow - b.blockOverflow;
+  // });
+  // const bestSolution = sortedSolutions.at(0)?.orientation;
 
-  if (!bestSolution) {
-    return;
-  }
+  // if (!bestSolution) {
+  //   return;
+  // }
 
-  if (bestSolution === lastTried) {
-    console.log(
-      `Given solutions ${JSON.stringify(
-        sortedSolutions,
-      )}, picking ${bestSolution} (last tried)`,
-    );
-  } else {
-    console.log(
-      `Given solutions ${JSON.stringify(
-        sortedSolutions,
-      )}, picking ${bestSolution} (redoing layout)`,
-    );
+  // if (bestSolution === lastTried) {
+  //   console.log(
+  //     `Given solutions ${JSON.stringify(
+  //       sortedSolutions,
+  //     )}, picking ${bestSolution} (last tried)`,
+  //   );
+  // } else {
+  //   console.log(
+  //     `Given solutions ${JSON.stringify(
+  //       sortedSolutions,
+  //     )}, picking ${bestSolution} (redoing layout)`,
+  //   );
 
-    tryOrientation({
-      popoverStage,
-      popoverContent,
-      anchorRect,
-      orientation: bestSolution,
-    });
-  }
+  //   tryOrientation({
+  //     popoverStage,
+  //     popoverContent,
+  //     anchorRect,
+  //     orientation: bestSolution,
+  //   });
+  // }
 
-  return bestSolution;
+  // return bestSolution;
 }
 
 /**

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -1,6 +1,14 @@
 // Prevent restoring the last-scrolled position from a previous session.
 history.scrollRestoration = 'manual';
 
+/**
+ * Due to WebKit's atrocious support for rendering fixed-position elements in
+ * vertical-rl documents, we render the dictionary on the native side instead.
+ * @type {"web" | "native"}
+ * @see https://bugs.webkit.org/show_bug.cgi?id=298992
+ */
+const popupRenderMode = 'native';
+
 {
   // Insert a viewport meta tag
   const meta = document.createElement('meta');
@@ -21,29 +29,6 @@ wrapRubyBaseTextsWithRb(document.body);
  * @param {number} obj.transactionId
  */
 function updatePopover({ results, tokenRange, transactionId }) {
-  /**
-   * We use <dialog> rather than popover mainly because light dismissal is even
-   * more broken in Safari 18 for popovers than it is for dialogs.
-   * @type {HTMLDialogElement}
-   */
-  const popover =
-    document.getElementById('paranovel-popover') ??
-    document.createElement('div');
-  const popoverStage =
-    document.getElementById('paranovel-popover-stage') ??
-    document.createElement('div');
-  const popoverContent =
-    document.getElementById('paranovel-popover-content') ??
-    document.createElement('div');
-  const anchor =
-    document.getElementById('paranovel-anchor') ??
-    document.createElement('div');
-  popover.id = 'paranovel-popover';
-  popoverStage.id = 'paranovel-popover-stage';
-  popoverContent.id = 'paranovel-popover-content';
-  anchor.id = 'paranovel-anchor';
-  popover.classList.remove('with-show-more-button');
-
   const rtsInRange = [...document.querySelectorAll('rt')].filter(
     rt => !tokenRange.intersectsNode(rt),
   );
@@ -73,6 +58,96 @@ function updatePopover({ results, tokenRange, transactionId }) {
     },
   };
 
+  // UI ported over from Paranovel v1's `src/screens/novel/DictView.tsx`.
+  // The container here maps to DictView's `ScrollView`, but we hoist its styles
+  // up to #paranovel-popover's CSS declaration instead.
+
+  // Now that we've got these anchors, we know the nodes and elements
+  // encompassed by the selected tokens. From here, we want to anchor the
+  // popover to them. Safari 26 does implement Anchor Positioning, but
+  // `height: 100%` is practically useless, meaning we would have to do manual
+  // layout to bound the popover height properly (and give up on position-try).
+  //
+  // At that rate, about the only benefit Anchor Positioning would give us would
+  // be the ability to align to the centre of the anchor.
+  //
+  // So, if not Anchor Positioning, what are our options? Now that we've got
+  // element "anchors", we can use HTMLElement.prototype.offsetLeft (etc.)
+  // instead of getBoundingClientRect(), so rather than laying out relative to
+  // the viewport (fixed positioning) we can finally draw relative to the
+  // scroll container (absolute positioning), allowing the popover to scroll
+  // along with the page.
+  //
+  // So, we have that option now. But it's tempting to go with fixed positioning
+  // just so that we can call range.getBoundingClientRect() instead of
+  // maintaining this complex element anchors code. With the new Popover API
+  // (supported in iOS 18), we could block body scroll and make the popover
+  // disappear upon clicking on the backdrop, so there'd be no need to mind
+  // about it scrolling along with the page.
+
+  document.body.classList.add('modal');
+  rtIsolationHack.apply();
+
+  const anchorRect = getEffectiveBoundingClientRect(tokenRange);
+  console.log(
+    `Anchor:\n- bounds:${JSON.stringify(anchorRect.toJSON())}\n${JSON.stringify(
+      [...tokenRange.getClientRects()],
+    )}`,
+  );
+
+  const endContainerElement =
+    tokenRange.endContainer instanceof Element
+      ? tokenRange.endContainer
+      : tokenRange.endContainer.parentElement;
+  /** @type {"horizontal-tb" | "vertical-rl" | "vertical-lr" | "sideways-lr" | "sideways-rl"} */
+  const writingMode =
+    endContainerElement?.computedStyleMap().get('writing-mode').value ??
+    'horizontal-tb';
+  const positionTryOrder = getBestPositionTryOrder(writingMode);
+
+  if (popupRenderMode === 'native') {
+    document.body.addEventListener('click', onClose);
+
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        type: 'present-native-popover',
+        id: transactionId,
+        positionTryOrder,
+        writingMode,
+        anchorRect: {
+          top: anchorRect.top,
+          right: anchorRect.right,
+          left: anchorRect.left,
+          bottom: anchorRect.bottom,
+          x: anchorRect.x,
+          y: anchorRect.y,
+          width: anchorRect.width,
+          height: anchorRect.height,
+        },
+        results: results ?? [],
+      }),
+    );
+    return;
+  }
+
+  const popover =
+    document.getElementById('paranovel-popover') ??
+    document.createElement('div');
+  const popoverStage =
+    document.getElementById('paranovel-popover-stage') ??
+    document.createElement('div');
+  const popoverContent =
+    document.getElementById('paranovel-popover-content') ??
+    document.createElement('div');
+  const anchor =
+    document.getElementById('paranovel-anchor') ??
+    document.createElement('div');
+  popover.id = 'paranovel-popover';
+  popoverStage.id = 'paranovel-popover-stage';
+  popoverContent.id = 'paranovel-popover-content';
+  anchor.id = 'paranovel-anchor';
+  popover.classList.remove('with-show-more-button');
+
   if (!popover.isConnected) {
     document.body.prepend(popover);
     popover.appendChild(popoverStage);
@@ -84,14 +159,9 @@ function updatePopover({ results, tokenRange, transactionId }) {
     document.body.prepend(anchor);
   }
 
-  // UI ported over from Paranovel v1's `src/screens/novel/DictView.tsx`.
-  // The container here maps to DictView's `ScrollView`, but we hoist its styles
-  // up to #paranovel-popover's CSS declaration instead.
-
-  const defaultFontSize = '14px';
-
   const container = document.createDocumentFragment();
 
+  const defaultFontSize = '14px';
   if (!results?.length) {
     const p = document.createElement('p');
     p.style.margin = '0';
@@ -165,75 +235,8 @@ function updatePopover({ results, tokenRange, transactionId }) {
   container.appendChild(resultsFragment);
   popoverContent.replaceChildren(container);
 
-  // Now that we've got these anchors, we know the nodes and elements
-  // encompassed by the selected tokens. From here, we want to anchor the
-  // popover to them. Safari 26 does implement Anchor Positioning, but
-  // `height: 100%` is practically useless, meaning we would have to do manual
-  // layout to bound the popover height properly (and give up on position-try).
-  //
-  // At that rate, about the only benefit Anchor Positioning would give us would
-  // be the ability to align to the centre of the anchor.
-  //
-  // So, if not Anchor Positioning, what are our options? Now that we've got
-  // element "anchors", we can use HTMLElement.prototype.offsetLeft (etc.)
-  // instead of getBoundingClientRect(), so rather than laying out relative to
-  // the viewport (fixed positioning) we can finally draw relative to the
-  // scroll container (absolute positioning), allowing the popover to scroll
-  // along with the page.
-  //
-  // So, we have that option now. But it's tempting to go with fixed positioning
-  // just so that we can call range.getBoundingClientRect() instead of
-  // maintaining this complex element anchors code. With the new Popover API
-  // (supported in iOS 18), we could block body scroll and make the popover
-  // disappear upon clicking on the backdrop, so there'd be no need to mind
-  // about it scrolling along with the page.
-
-  document.body.classList.add('modal');
-  rtIsolationHack.apply();
   popover.dataset.open = '';
   popover.style.setProperty('visibility', 'hidden');
-
-  const anchorRect = getEffectiveBoundingClientRect(tokenRange);
-  console.log(
-    `Anchor:\n- bounds:${JSON.stringify(anchorRect.toJSON())}\n${JSON.stringify(
-      [...tokenRange.getClientRects()],
-    )}`,
-  );
-
-  const endContainerElement =
-    tokenRange.endContainer instanceof Element
-      ? tokenRange.endContainer
-      : tokenRange.endContainer.parentElement;
-  /** @type {"horizontal-tb" | "vertical-rl" | "vertical-lr" | "sideways-lr" | "sideways-rl"} */
-  const writingMode =
-    endContainerElement?.computedStyleMap().get('writing-mode').value ??
-    'horizontal-tb';
-  const positionTryOrder = getBestPositionTryOrder(writingMode);
-
-  /** @type {"web" | "native"} */
-  const popupRenderMode = 'native';
-  if (popupRenderMode === 'native') {
-    window.ReactNativeWebView.postMessage(
-      JSON.stringify({
-        type: 'present-native-popover',
-        id: transactionId,
-        positionTryOrder,
-        writingMode,
-        anchorRect: {
-          top: anchorRect.top,
-          right: anchorRect.right,
-          left: anchorRect.left,
-          bottom: anchorRect.bottom,
-          x: anchorRect.x,
-          y: anchorRect.y,
-          width: anchorRect.width,
-          height: anchorRect.height,
-        },
-        results: results ?? [],
-      }),
-    );
-    return;
-  }
 
   console.log(
     `Anchor:\n- bounds:${JSON.stringify(anchorRect.toJSON())}\n${JSON.stringify(
@@ -273,13 +276,18 @@ function updatePopover({ results, tokenRange, transactionId }) {
 
   /** @param {MouseEvent} event */
   function onClose(event) {
-    if (popoverContent.contains(event.target)) {
+    const popover = document.getElementById('paranovel-popover');
+    const popoverContent = document.getElementById('paranovel-popover-content');
+
+    if (popoverContent?.contains(event.target)) {
       console.log('contained', event.currentTarget);
       return;
     }
     console.log('out!');
 
-    delete popover.dataset.open;
+    if (popover) {
+      delete popover.dataset.open;
+    }
     __paranovelState.wordHighlight.clear();
     rtIsolationHack.remove();
 

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -192,7 +192,69 @@ function updatePopover({ results, tokenRange, transactionId }) {
   rtIsolationHack.apply();
   popover.dataset.open = '';
   popover.style.setProperty('visibility', 'hidden');
-  const orientation = layOutPopover({
+
+  const anchorRect = getEffectiveBoundingClientRect(tokenRange);
+  console.log(
+    `Anchor:\n- bounds:${JSON.stringify(anchorRect.toJSON())}\n${JSON.stringify(
+      [...tokenRange.getClientRects()],
+    )}`,
+  );
+
+  const endContainerElement =
+    tokenRange.endContainer instanceof Element
+      ? tokenRange.endContainer
+      : tokenRange.endContainer.parentElement;
+  /** @type {"horizontal-tb" | "vertical-rl" | "vertical-lr" | "sideways-lr" | "sideways-rl"} */
+  const writingMode =
+    endContainerElement?.computedStyleMap().get('writing-mode').value ??
+    'horizontal-tb';
+  const positionTryOrder = getBestPositionTryOrder(writingMode);
+
+  /** @type {"web" | "native"} */
+  const popupRenderMode = 'native';
+  if (popupRenderMode === 'native') {
+    window.ReactNativeWebView.postMessage(
+      JSON.stringify({
+        type: 'present-native-popover',
+        id: transactionId,
+        positionTryOrder,
+        writingMode,
+        anchorRect: {
+          top: anchorRect.top,
+          right: anchorRect.right,
+          left: anchorRect.left,
+          bottom: anchorRect.bottom,
+          x: anchorRect.x,
+          y: anchorRect.y,
+          width: anchorRect.width,
+          height: anchorRect.height,
+        },
+        results: results ?? [],
+      }),
+    );
+    return;
+  }
+
+  console.log(
+    `Anchor:\n- bounds:${JSON.stringify(anchorRect.toJSON())}\n${JSON.stringify(
+      [...tokenRange.getClientRects()],
+    )}`,
+  );
+  anchor.style.left = `${anchorRect.left}px`;
+  anchor.style.top = `${anchorRect.top}px`;
+  anchor.style.width = `${anchorRect.width}px`;
+  anchor.style.height = `${anchorRect.height}px`;
+
+  if (
+    writingMode === 'lr' ||
+    writingMode === 'lr-tb' ||
+    writingMode === 'rl' ||
+    writingMode === 'horizontal-tb'
+  ) {
+    popoverStage.style.overflow = '';
+  }
+
+  const orientation = determineBestOrientation({
     anchor,
     popoverStage,
     popoverContent,
@@ -206,8 +268,8 @@ function updatePopover({ results, tokenRange, transactionId }) {
     return;
   }
 
-  // popoverContent.scrollTop = 0;
-  // popover.style.setProperty('visibility', 'visible');
+  popoverContent.scrollTop = 0;
+  popover.style.setProperty('visibility', 'visible');
 
   /** @param {MouseEvent} event */
   function onClose(event) {
@@ -230,41 +292,96 @@ function updatePopover({ results, tokenRange, transactionId }) {
 
 /**
  * @param {object} obj
- * @param {HTMLDivElement} obj.anchor
+ * @param {["bottom", "top"] | ["right", "left"] | ["left", "right"]} obj.positionTryOrder
+ * @param {DOMRect} obj.anchorRect
  * @param {HTMLElement} obj.popoverStage
  * @param {HTMLElement} obj.popoverContent
- * @param {Range} obj.tokenRange
- * @param {number} obj.transactionId
- * @param {Array<import("../../utils/look-up-term").LookupResult>} [obj.results]
  */
-function layOutPopover({
-  anchor,
+function determineBestOrientation({
+  positionTryOrder,
+  anchorRect,
   popoverStage,
   popoverContent,
-  tokenRange,
-  results,
-  transactionId,
 }) {
-  const anchorRect = getEffectiveBoundingClientRect(tokenRange);
-  console.log(
-    `Anchor:\n- bounds:${JSON.stringify(anchorRect.toJSON())}\n${JSON.stringify(
-      [...tokenRange.getClientRects()],
-    )}`,
-  );
-  anchor.style.left = `${anchorRect.left}px`;
-  anchor.style.top = `${anchorRect.top}px`;
-  anchor.style.width = `${anchorRect.width}px`;
-  anchor.style.height = `${anchorRect.height}px`;
+  /** @type {Array<{ orientation: Orientation, blockOverflow: number, clientInlineSize: number }>} */
+  const solutions = [];
+  /** @type {Orientation} */
+  let lastTried;
+  for (const orientation of positionTryOrder) {
+    lastTried = orientation;
+    const {
+      blockOverflow,
+      inlineOverflow,
+      clientInlineSize,
+      isOverflowingViewport,
+      stageRect,
+    } = tryOrientation({
+      popoverStage,
+      popoverContent,
+      anchorRect,
+      orientation,
+    });
+    if (isOverflowingViewport) {
+      console.log(
+        `Discarding orientation "${orientation}" as it's overflowing the viewport.`,
+        stageRect,
+      );
+      continue;
+    }
+    if (inlineOverflow) {
+      console.log(
+        `Discarding orientation "${orientation}" as it's overflowing in the inline orientation.`,
+        stageRect,
+      );
+      continue;
+    }
+    solutions.push({ orientation, blockOverflow, clientInlineSize });
+  }
+  const sortedSolutions = solutions.sort((a, b) => {
+    // Sort in descending order of inline size.
+    const clientInlineSize = b.clientInlineSize - a.clientInlineSize;
+    // If there's no tie, use that alone as the sorting factor.
+    if (clientInlineSize) {
+      return clientInlineSize;
+    }
+    // Otherwise, sort in ascending order of block overflow.
+    //
+    // (Given that we reserve the same amount of block space for both
+    // orientations, though, this won't actually make any difference unless we
+    // change the layout algorithm in future.)
+    return a.blockOverflow - b.blockOverflow;
+  });
+  const bestSolution = sortedSolutions.at(0)?.orientation;
+  if (!bestSolution) {
+    return;
+  }
+  if (bestSolution === lastTried) {
+    console.log(
+      `Given solutions ${JSON.stringify(
+        sortedSolutions,
+      )}, picking ${bestSolution} (last tried)`,
+    );
+  } else {
+    console.log(
+      `Given solutions ${JSON.stringify(
+        sortedSolutions,
+      )}, picking ${bestSolution} (redoing layout)`,
+    );
+    tryOrientation({
+      popoverStage,
+      popoverContent,
+      anchorRect,
+      orientation: bestSolution,
+    });
+  }
+  return bestSolution;
+}
 
-  const endContainerElement =
-    tokenRange.endContainer instanceof Element
-      ? tokenRange.endContainer
-      : tokenRange.endContainer.parentElement;
-  /** @type {"horizontal-tb" | "vertical-rl" | "vertical-lr" | "sideways-lr" | "sideways-rl"} */
-  const writingMode =
-    endContainerElement?.computedStyleMap().get('writing-mode').value ??
-    'horizontal-tb';
-
+/**
+ * @param {"horizontal-tb" | "vertical-rl" | "vertical-lr" | "sideways-lr" | "sideways-rl"} writingMode
+ * @returns {['bottom', 'top'] | ['right', 'left'] | ['left', 'right']}
+ */
+function getBestPositionTryOrder(writingMode) {
   /**
    * A tactic to emulate the following CSS:
    *
@@ -272,18 +389,13 @@ function layOutPopover({
    * position-area: block-end span-all;
    * position-try: most-block-size flip-block;
    * ```
-   *
-   * @type {["bottom", "top"] | ["right", "left"] | ["left", "right"]}
    */
-  let positionTryOrder;
   switch (writingMode) {
     case 'lr':
     case 'lr-tb':
     case 'rl':
     case 'horizontal-tb': {
-      positionTryOrder = ['bottom', 'top'];
-      popoverStage.style.overflow = '';
-      break;
+      return ['bottom', 'top'];
     }
     case 'tb-lr':
     case 'tb-rl':
@@ -291,118 +403,12 @@ function layOutPopover({
     case 'vertical-rl':
     case 'sideways-lr':
     case 'vertical-lr': {
-      positionTryOrder = writingMode.endsWith('rl')
-        ? ['left', 'right']
-        : ['right', 'left'];
-      break;
+      return writingMode.endsWith('rl') ? ['left', 'right'] : ['right', 'left'];
     }
     default: {
       throw new Error(`Unexpected writing mode, ${writingMode}`);
     }
   }
-
-  // TODO: Return here?
-  window.ReactNativeWebView.postMessage(
-    JSON.stringify({
-      type: 'present-native-popover',
-      id: transactionId,
-      positionTryOrder,
-      writingMode,
-      anchorRect: {
-        top: anchorRect.top,
-        right: anchorRect.right,
-        left: anchorRect.left,
-        bottom: anchorRect.bottom,
-        x: anchorRect.x,
-        y: anchorRect.y,
-        width: anchorRect.width,
-        height: anchorRect.height,
-      },
-      results: results ?? [],
-    }),
-  );
-
-  // /** @type {Array<{ orientation: Orientation, blockOverflow: number, clientInlineSize: number }>} */
-  // const solutions = [];
-  // /** @type {Orientation} */
-  // let lastTried;
-  // for (const orientation of positionTryOrder) {
-  //   lastTried = orientation;
-  //   const {
-  //     blockOverflow,
-  //     inlineOverflow,
-  //     clientInlineSize,
-  //     isOverflowingViewport,
-  //     stageRect,
-  //   } = tryOrientation({
-  //     popoverStage,
-  //     popoverContent,
-  //     anchorRect,
-  //     orientation,
-  //   });
-
-  //   if (isOverflowingViewport) {
-  //     console.log(
-  //       `Discarding orientation "${orientation}" as it's overflowing the viewport.`,
-  //       stageRect,
-  //     );
-  //     continue;
-  //   }
-  //   if (inlineOverflow) {
-  //     console.log(
-  //       `Discarding orientation "${orientation}" as it's overflowing in the inline orientation.`,
-  //       stageRect,
-  //     );
-  //     continue;
-  //   }
-
-  //   solutions.push({ orientation, blockOverflow, clientInlineSize });
-  // }
-
-  // const sortedSolutions = solutions.sort((a, b) => {
-  //   // Sort in descending order of inline size.
-  //   const clientInlineSize = b.clientInlineSize - a.clientInlineSize;
-
-  //   // If there's no tie, use that alone as the sorting factor.
-  //   if (clientInlineSize) {
-  //     return clientInlineSize;
-  //   }
-
-  //   // Otherwise, sort in ascending order of block overflow.
-  //   //
-  //   // (Given that we reserve the same amount of block space for both
-  //   // orientations, though, this won't actually make any difference unless we
-  //   // change the layout algorithm in future.)
-  //   return a.blockOverflow - b.blockOverflow;
-  // });
-  // const bestSolution = sortedSolutions.at(0)?.orientation;
-
-  // if (!bestSolution) {
-  //   return;
-  // }
-
-  // if (bestSolution === lastTried) {
-  //   console.log(
-  //     `Given solutions ${JSON.stringify(
-  //       sortedSolutions,
-  //     )}, picking ${bestSolution} (last tried)`,
-  //   );
-  // } else {
-  //   console.log(
-  //     `Given solutions ${JSON.stringify(
-  //       sortedSolutions,
-  //     )}, picking ${bestSolution} (redoing layout)`,
-  //   );
-
-  //   tryOrientation({
-  //     popoverStage,
-  //     popoverContent,
-  //     anchorRect,
-  //     orientation: bestSolution,
-  //   });
-  // }
-
-  // return bestSolution;
 }
 
 /**

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -106,8 +106,6 @@ function updatePopover({ results, tokenRange, transactionId }) {
   const positionTryOrder = getBestPositionTryOrder(writingMode);
 
   if (popupRenderMode === 'native') {
-    document.body.addEventListener('click', onClose);
-
     window.ReactNativeWebView.postMessage(
       JSON.stringify({
         type: 'present-native-popover',
@@ -275,12 +273,12 @@ function updatePopover({ results, tokenRange, transactionId }) {
   popover.style.setProperty('visibility', 'visible');
 }
 
-/** @param {MouseEvent} event */
+/** @param {MouseEvent} [event] */
 function onClose(event) {
   const popover = document.getElementById('paranovel-popover');
   const popoverContent = document.getElementById('paranovel-popover-content');
 
-  if (popoverContent?.contains(event.target)) {
+  if (event && popoverContent?.contains(event.target)) {
     console.log('contained', event.currentTarget);
     return;
   }
@@ -293,9 +291,13 @@ function onClose(event) {
   __paranovelState.rtIsolationHack?.remove();
 
   // Stop this click propagating to the document-level click handler.
-  event.stopPropagation();
+  event?.stopPropagation();
 
   document.body.classList.remove('modal');
+
+  window.ReactNativeWebView.postMessage(
+    JSON.stringify({ type: 'close-native-popover' }),
+  );
 }
 
 /**
@@ -712,6 +714,11 @@ function log(message) {
 async function onClickDocument(event) {
   const { x, y, target } = event;
 
+  if (__paranovelState.nativeModalVisible) {
+    onClose();
+    return;
+  }
+
   if (
     document.getElementById('paranovel-popover')?.contains(target) ||
     document.getElementById('paranovel-prelude')?.contains(target) ||
@@ -722,10 +729,10 @@ async function onClickDocument(event) {
     return;
   }
 
-  const anchor = document.getElementById('paranovel-anchor');
-  if (anchor?.childNodes.length) {
-    dissolveAnchor(anchor);
-  }
+  // const anchor = document.getElementById('paranovel-anchor');
+  // if (anchor?.childNodes.length) {
+  //   dissolveAnchor(anchor);
+  // }
 
   // This rounds to the nearest glyph. That is to say, given the text "abc",
   // your click will be funnelled into "b" if it is:
@@ -735,6 +742,7 @@ async function onClickDocument(event) {
   const caretRange = document.caretRangeFromPoint(x, y);
   if (!caretRange) {
     log('❌ no caret range');
+    onClose();
     return;
   }
 
@@ -744,6 +752,7 @@ async function onClickDocument(event) {
   const surroundingText = getSurroundingText(adjustedRange);
   if (!surroundingText) {
     log('❌ no surrounding text');
+    onClose();
     return;
   }
   // console.log(surroundingText);
@@ -799,6 +808,7 @@ async function onClickDocument(event) {
     endOffset: offsetOfTargetTokenIntoBlockBaseText + tokenLength,
   });
   if (!tokenRange) {
+    onClose();
     return;
   }
 
@@ -837,6 +847,7 @@ async function onClickDocument(event) {
 
   console.log('onClickDocument', { tokenRange });
   window.tokenRange = tokenRange;
+  __paranovelState.wordHighlight.clear();
   __paranovelState.wordHighlight.add(tokenRange);
 
   log(`🔎 Looking up term "${dictionaryForm}"`);
@@ -1412,13 +1423,15 @@ function restoreScroll() {
   }
 }
 
-/** @type {{ wordHighlight: Highlight; tokenizationPromiseCount: number; tokenizationPromiseHandlers: Record<number, { resolve: () => void; reject: (reason?: any) => void; }>; rtIsolationHack: { apply: () => void; remove: () => void; } | undefined }} */
+/** @type {{ wordHighlight: Highlight; tokenizationPromiseCount: number; tokenizationPromiseHandlers: Record<number, { resolve: () => void; reject: (reason?: any) => void; }>; rtIsolationHack: { apply: () => void; remove: () => void; } | undefined; nativeModalVisible: boolean }} */
 const __paranovelState = {
   wordHighlight: new Highlight(),
   tokenizationPromiseCount: 0,
   tokenizationPromiseHandlers: {},
   rtIsolationHack: undefined,
+  nativeModalVisible: false,
 };
+window.__paranovelState = __paranovelState;
 
 /**
  * Necessarily lazy because writing mode can't be correctly resolved until we've

--- a/src/source-assets/injected-javascript.wvjs
+++ b/src/source-assets/injected-javascript.wvjs
@@ -18,8 +18,9 @@ wrapRubyBaseTextsWithRb(document.body);
  * @param {object} obj
  * @param {Array<import("../../utils/look-up-term").LookupResult>} [obj.results]
  * @param {Range} obj.tokenRange
+ * @param {number} obj.transactionId
  */
-function updatePopover({ results, tokenRange }) {
+function updatePopover({ results, tokenRange, transactionId }) {
   /**
    * We use <dialog> rather than popover mainly because light dismissal is even
    * more broken in Safari 18 for popovers than it is for dialogs.
@@ -196,6 +197,8 @@ function updatePopover({ results, tokenRange }) {
     popoverStage,
     popoverContent,
     tokenRange,
+    transactionId,
+    results,
   });
   if (!orientation) {
     onClose();
@@ -229,8 +232,17 @@ function updatePopover({ results, tokenRange }) {
  * @param {HTMLElement} obj.popoverStage
  * @param {HTMLElement} obj.popoverContent
  * @param {Range} obj.tokenRange
+ * @param {number} obj.transactionId
+ * @param {Array<import("../../utils/look-up-term").LookupResult>} [obj.results]
  */
-function layOutPopover({ anchor, popoverStage, popoverContent, tokenRange }) {
+function layOutPopover({
+  anchor,
+  popoverStage,
+  popoverContent,
+  tokenRange,
+  results,
+  transactionId,
+}) {
   const anchorRect = getEffectiveBoundingClientRect(tokenRange);
   console.log(
     `Anchor:\n- bounds:${JSON.stringify(anchorRect.toJSON())}\n${JSON.stringify(
@@ -286,6 +298,42 @@ function layOutPopover({ anchor, popoverStage, popoverContent, tokenRange }) {
       throw new Error(`Unexpected writing mode, ${writingMode}`);
     }
   }
+
+  const payload = {
+    id: transactionId,
+    positionTryOrder,
+    anchorRect: {
+      top: anchorRect.top,
+      right: anchorRect.right,
+      left: anchorRect.left,
+      bottom: anchorRect.bottom,
+      x: anchorRect.x,
+      y: anchorRect.y,
+      width: anchorRect.width,
+      height: anchorRect.height,
+    },
+    results: results ?? [],
+  };
+
+  // TODO: Return here?
+  window.ReactNativeWebView.postMessage(
+    JSON.stringify({
+      type: 'present-native-popover',
+      id: transactionId,
+      positionTryOrder,
+      anchorRect: {
+        top: anchorRect.top,
+        right: anchorRect.right,
+        left: anchorRect.left,
+        bottom: anchorRect.bottom,
+        x: anchorRect.x,
+        y: anchorRect.y,
+        width: anchorRect.width,
+        height: anchorRect.height,
+      },
+      results: results ?? [],
+    }),
+  );
 
   /** @type {Array<{ orientation: Orientation, blockOverflow: number, clientInlineSize: number }>} */
   const solutions = [];
@@ -1042,6 +1090,7 @@ async function lookUpTerm({ dictionaryForm, tokenRange }) {
   updatePopover({
     results: response,
     tokenRange,
+    transactionId: id,
   });
 }
 


### PR DESCRIPTION
This PR introduces `popupRenderMode: "web" | "native"`, to work around WebKit's [absymal support](https://bugs.webkit.org/show_bug.cgi?id=298992) for any kind of fixed-position element in `writing-mode: vertical-rl` documents.

Some compromises made, to be sure. Native styles are less expressive (I'm not looking forward to implementing the "show more" functionality, that clips dictionary results to just the first one – I'm inclined just to drop it altogether), and now we have the headache of dancing between two worlds.

The app was originally set up to pass dictionary results from native to web, but because of these unanticipated WebKit bugs, we're stupidly passing the dictionary results into web only to send them straight back to native to be presented. Can't be bothered to address that inefficiency with this PR though (and who knows, maybe we'll eventually go back to rendering in web).

But on the other hand, the DX is materially better in a sense, as I can now hot-reload more of the popover logic, such as layout and design.